### PR TITLE
feat(fetch): Add Basic Auth support for Swagger spec endpoints

### DIFF
--- a/docs/superpowers/specs/2026-04-11-swagger-auth-design.md
+++ b/docs/superpowers/specs/2026-04-11-swagger-auth-design.md
@@ -1,0 +1,128 @@
+# Basic Auth for Swagger Spec Fetching
+
+## Context
+
+The user added Basic Auth to their Swagger JSON endpoint. chowbea-axios now fails to fetch the OpenAPI spec because it can't pass credentials. The existing `[fetch.headers]` config requires manually base64-encoding credentials — this feature adds first-class Basic Auth support with an interactive fallback.
+
+## Design
+
+### New Config Section: `[fetch.auth]`
+
+```toml
+[fetch.auth]
+type = "basic"
+username = "$SWAGGER_USER"     # env var interpolation supported
+password = "$SWAGGER_PASS"     # env var interpolation supported
+```
+
+- `type`: Only `"basic"` supported for now. Validated at config load time.
+- `username` / `password`: Support `$VAR` and `${VAR}` syntax via existing `interpolateEnvVars()`.
+- All fields are optional — if `[fetch.auth]` section exists with `type = "basic"` but credentials are missing, the user is prompted interactively.
+
+### New Interface: `FetchAuthConfig`
+
+```typescript
+// in src/core/config.ts
+export interface FetchAuthConfig {
+  type: "basic";
+  username?: string;
+  password?: string;
+}
+```
+
+Added as optional field on `FetchConfig`:
+```typescript
+export interface FetchConfig {
+  headers?: Record<string, string>;
+  auth?: FetchAuthConfig;
+}
+```
+
+### PromptProvider Extension
+
+Add `password()` method to the existing `PromptProvider` interface:
+
+```typescript
+password(opts: {
+  message: string;
+  mask?: string;
+}): Promise<string>;
+```
+
+- **Headless**: Uses `@inquirer/prompts` `password()` (masks input with `*`)
+- **TUI**: Uses masked `input()` component
+
+### Auth Resolution Flow
+
+In `executeFetch()`:
+
+1. Read `config.fetch?.auth`
+2. If `auth.type === "basic"`:
+   a. Try to resolve `username` and `password` via env var interpolation
+   b. If either is missing/empty and stdin is a TTY → prompt interactively via `PromptProvider`
+   c. If either is missing/empty and stdin is NOT a TTY → throw error with message to set env vars
+3. Pass resolved `{ username, password }` to `fetchOpenApiSpec()`
+4. `fetchOpenApiSpec()` constructs `Authorization: Basic <base64(user:pass)>` header
+
+### Changes to `executeFetch()` Signature
+
+```typescript
+export async function executeFetch(
+  options: FetchActionOptions,
+  logger: Logger,
+  prompts?: PromptProvider,  // optional — only needed when auth requires interactive input
+): Promise<FetchActionResult>
+```
+
+### Changes to `fetchOpenApiSpec()`
+
+Add optional `auth` to the options:
+
+```typescript
+export async function fetchOpenApiSpec(options: {
+  // ... existing fields ...
+  auth?: { username: string; password: string };
+}): Promise<FetchResult>
+```
+
+If `auth` is provided, construct and add the header:
+```typescript
+const credentials = Buffer.from(`${auth.username}:${auth.password}`).toString("base64");
+headers["Authorization"] = `Basic ${credentials}`;
+```
+
+### Config Template Update
+
+`generateConfigTemplate()` updated to include commented-out auth section:
+```toml
+# [fetch.auth]
+# type = "basic"
+# username = "$SWAGGER_USER"
+# password = "$SWAGGER_PASS"
+```
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/core/config.ts` | Add `FetchAuthConfig` interface, update `FetchConfig`, add `validateFetchAuthConfig()`, update `generateConfigTemplate()` |
+| `src/core/fetcher.ts` | Accept `auth` option in `fetchOpenApiSpec()`, construct Basic Auth header |
+| `src/core/actions/fetch.ts` | Add auth resolution logic, accept optional `PromptProvider`, prompt when credentials missing |
+| `src/core/actions/init.ts` | Add `password()` to `PromptProvider` interface |
+| `src/headless/runner.ts` | Add `password()` to headless prompt provider, pass prompts to `executeFetch()` |
+| `src/tui/screens/fetch-generate.tsx` | If `config.fetch?.auth` is configured with incomplete credentials, show username/password input fields before running fetch. Pass resolved credentials via `FetchActionOptions` so no interactive prompt is needed mid-fetch. |
+
+## Error Handling
+
+- Invalid `type` value → `ConfigValidationError` at config load
+- Env var not set + non-TTY → clear error: "Set $SWAGGER_USER and $SWAGGER_PASS environment variables, or run interactively"
+- User cancels prompt → graceful abort, no stack trace
+- 401 after providing credentials → normal `NetworkError` with HTTP 401 status (existing behavior)
+
+## Verification
+
+1. **Config-based auth**: Set env vars `SWAGGER_USER` and `SWAGGER_PASS`, add `[fetch.auth]` to config, run `chowbea-axios fetch` — should succeed
+2. **Interactive auth**: Add `[fetch.auth]` with `type = "basic"` but no credentials, run `chowbea-axios fetch` — should prompt for username/password
+3. **No auth**: Remove `[fetch.auth]` section — should work exactly as before (no regression)
+4. **Invalid config**: Set `type = "invalid"` — should throw validation error
+5. **Non-interactive fallback**: Pipe stdin, no env vars — should throw clear error message

--- a/docs/superpowers/specs/2026-04-11-swagger-auth-design.md
+++ b/docs/superpowers/specs/2026-04-11-swagger-auth-design.md
@@ -49,19 +49,31 @@ password(opts: {
 }): Promise<string>;
 ```
 
-- **Headless**: Uses `@inquirer/prompts` `password()` (masks input with `*`)
-- **TUI**: Uses masked `input()` component
+- **Headless**: Uses `@inquirer/prompts` `password()` (masks input with `*`).
+  Only wired when stdin/stdout are TTY — CI/piped contexts skip prompts and
+  fall through to the clear "credentials incomplete" error path.
+- **TUI**: The `PromptProvider` replay implementations in `init-wizard.tsx`
+  and `plugins-manager.tsx` stub `password()` as a no-op returning `""` (they
+  don't need credential prompts). The `fetch-generate.tsx` screen handles
+  auth differently — it pre-resolves credentials via its own input UI and
+  passes them through `FetchActionOptions.auth`, bypassing the
+  `PromptProvider` path entirely.
 
 ### Auth Resolution Flow
 
 In `executeFetch()`:
 
-1. Read `config.fetch?.auth`
-2. If `auth.type === "basic"`:
+1. If `options.auth` is provided (e.g., from TUI pre-resolution), use it directly
+2. Otherwise, read `config.fetch?.auth`
+3. If `auth.type === "basic"`:
    a. Try to resolve `username` and `password` via env var interpolation
-   b. If either is missing/empty and stdin is a TTY → prompt interactively via `PromptProvider`
-   c. If either is missing/empty and stdin is NOT a TTY → throw error with message to set env vars
-3. Pass resolved `{ username, password }` to `fetchOpenApiSpec()`
+   b. If both resolved → return credentials
+   c. If either is missing and a `PromptProvider` is provided (TTY only) → prompt interactively
+   d. After prompting, validate non-empty username/password; throw if either is empty
+   e. If no `PromptProvider` (non-TTY/CI) → throw error with message to set env vars
+4. Pass resolved `{ username, password }` to `fetchOpenApiSpec()`
+
+The headless CLI only constructs its `PromptProvider` when both `process.stdin.isTTY` and `process.stdout.isTTY` are truthy, so CI/piped runs always hit the clear error path instead of hanging on stdin.
 4. `fetchOpenApiSpec()` constructs `Authorization: Basic <base64(user:pass)>` header
 
 ### Changes to `executeFetch()` Signature
@@ -72,6 +84,15 @@ export async function executeFetch(
   logger: Logger,
   prompts?: PromptProvider,  // optional — only needed when auth requires interactive input
 ): Promise<FetchActionResult>
+```
+
+`FetchActionOptions` gains an optional `auth` field for callers (like the TUI) that resolve credentials via their own UI:
+
+```typescript
+export interface FetchActionOptions {
+  // ... existing fields ...
+  auth?: { username: string; password: string };
+}
 ```
 
 ### Changes to `fetchOpenApiSpec()`
@@ -85,9 +106,13 @@ export async function fetchOpenApiSpec(options: {
 }): Promise<FetchResult>
 ```
 
-If `auth` is provided, construct and add the header:
+If `auth` is provided, construct and add the header. Any existing `Authorization` header is removed case-insensitively first, so Basic Auth always wins regardless of how the config header was cased:
+
 ```typescript
 const credentials = Buffer.from(`${auth.username}:${auth.password}`).toString("base64");
+for (const key of Object.keys(headers)) {
+  if (key.toLowerCase() === "authorization") delete headers[key];
+}
 headers["Authorization"] = `Basic ${credentials}`;
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chowbea-axios",
-  "version": "2.0.0-alpha.13",
+  "version": "2.0.0-alpha.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chowbea-axios",
-      "version": "2.0.0-alpha.13",
+      "version": "2.0.0-alpha.18",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",

--- a/src/core/actions/fetch.ts
+++ b/src/core/actions/fetch.ts
@@ -8,16 +8,19 @@ import type { Logger } from "../../adapters/logger-interface.js";
 import { formatDuration } from "../../adapters/logger-interface.js";
 import {
 	ensureOutputFolders,
+	type FetchAuthConfig,
 	getOutputPaths,
 	loadConfig,
 	resolveSpecSource,
 } from "../config.js";
 import {
 	fetchOpenApiSpec,
+	interpolateEnvVars,
 	loadLocalSpecFile,
 	saveSpec,
 } from "../fetcher.js";
 import { generate, generateClientFiles } from "../generator.js";
+import type { PromptProvider } from "./init.js";
 import type { ClientFilesResult, DryRunResult } from "./types.js";
 
 /**
@@ -63,15 +66,80 @@ export interface FetchActionResult {
 }
 
 /**
+ * Resolves Basic Auth credentials from config, env vars, or interactive prompts.
+ * Returns resolved credentials or undefined if no auth is configured.
+ */
+async function resolveBasicAuth(
+	authConfig: FetchAuthConfig,
+	logger: Logger,
+	prompts?: PromptProvider,
+): Promise<{ username: string; password: string }> {
+	let username: string | undefined;
+	let password: string | undefined;
+
+	// Try resolving username from config (with env var interpolation)
+	if (authConfig.username) {
+		try {
+			username = interpolateEnvVars(authConfig.username);
+		} catch {
+			// Env var not set — will prompt or error below
+		}
+	}
+
+	// Try resolving password from config (with env var interpolation)
+	if (authConfig.password) {
+		try {
+			password = interpolateEnvVars(authConfig.password);
+		} catch {
+			// Env var not set — will prompt or error below
+		}
+	}
+
+	// If credentials are complete, return them
+	if (username && password) {
+		logger.debug("Using Basic Auth credentials from config/env");
+		return { username, password };
+	}
+
+	// Try interactive prompts
+	if (prompts) {
+		logger.info("Basic Auth credentials needed for spec endpoint");
+
+		if (!username) {
+			username = await prompts.input({
+				message: "Swagger username:",
+			});
+		}
+		if (!password) {
+			password = await prompts.password({
+				message: "Swagger password:",
+				mask: "*",
+			});
+		}
+
+		return { username, password };
+	}
+
+	// Non-interactive and credentials are incomplete
+	throw new Error(
+		"Basic Auth credentials are incomplete. " +
+			"Set the environment variables referenced in [fetch.auth] " +
+			"(e.g. SWAGGER_USER, SWAGGER_PASS), or run interactively to be prompted."
+	);
+}
+
+/**
  * Executes the fetch action: fetch OpenAPI spec, cache it, and generate types/operations.
  *
  * @param options - Fetch action options (replaces CLI flags)
  * @param logger - Logger instance for output
+ * @param prompts - Optional prompt provider for interactive auth credential input
  * @returns Structured result with all data the UI needs
  */
 export async function executeFetch(
 	options: FetchActionOptions,
 	logger: Logger,
+	prompts?: PromptProvider,
 ): Promise<FetchActionResult> {
 	const startTime = Date.now();
 
@@ -128,6 +196,12 @@ export async function executeFetch(
 		logger.step("fetch", "Fetching OpenAPI spec...");
 		logger.debug({ endpoint: specSource.endpoint }, "endpoint");
 
+		// Resolve auth credentials if configured
+		let auth: { username: string; password: string } | undefined;
+		if (config.fetch?.auth?.type === "basic") {
+			auth = await resolveBasicAuth(config.fetch.auth, logger, prompts);
+		}
+
 		fetchResult = await fetchOpenApiSpec({
 			endpoint: specSource.endpoint,
 			specPath: outputPaths.spec,
@@ -135,6 +209,7 @@ export async function executeFetch(
 			logger,
 			force: options.force,
 			headers: config.fetch?.headers,
+			auth,
 		});
 
 		// Handle network fallback

--- a/src/core/actions/fetch.ts
+++ b/src/core/actions/fetch.ts
@@ -41,6 +41,12 @@ export interface FetchActionOptions {
 	typesOnly: boolean;
 	/** Generate only operations (skip types) */
 	operationsOnly: boolean;
+	/**
+	 * Pre-resolved Basic Auth credentials. When provided, overrides
+	 * config-based env var lookup and skips interactive prompts.
+	 * Used by the TUI to collect credentials via its own UI layer.
+	 */
+	auth?: { username: string; password: string };
 }
 
 /**
@@ -108,6 +114,8 @@ async function resolveBasicAuth(
 		if (!username) {
 			username = await prompts.input({
 				message: "Swagger username:",
+				validate: (value) =>
+					value.trim().length > 0 ? true : "Username is required",
 			});
 		}
 		if (!password) {
@@ -115,6 +123,12 @@ async function resolveBasicAuth(
 				message: "Swagger password:",
 				mask: "*",
 			});
+		}
+
+		if (!username?.trim() || !password) {
+			throw new Error(
+				"Basic Auth credentials are incomplete. Both username and password are required."
+			);
 		}
 
 		return { username, password };
@@ -196,9 +210,14 @@ export async function executeFetch(
 		logger.step("fetch", "Fetching OpenAPI spec...");
 		logger.debug({ endpoint: specSource.endpoint }, "endpoint");
 
-		// Resolve auth credentials if configured
+		// Resolve auth credentials if configured.
+		// Caller-supplied options.auth (e.g., from TUI) takes precedence
+		// over config-based env var lookup and interactive prompts.
 		let auth: { username: string; password: string } | undefined;
-		if (config.fetch?.auth?.type === "basic") {
+		if (options.auth) {
+			auth = options.auth;
+			logger.debug("Using Basic Auth credentials from caller");
+		} else if (config.fetch?.auth?.type === "basic") {
 			auth = await resolveBasicAuth(config.fetch.auth, logger, prompts);
 		}
 

--- a/src/core/actions/init.ts
+++ b/src/core/actions/init.ts
@@ -77,6 +77,8 @@ export interface PromptProvider {
 
   confirm(opts: { message: string; default?: boolean }): Promise<boolean>;
 
+  password(opts: { message: string; mask?: string }): Promise<string>;
+
   checkbox<T>(opts: {
     message: string;
     choices: Array<{ name: string; value: T }>;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -10,11 +10,26 @@ import toml from "toml";
 import { ConfigError, ConfigValidationError } from "./errors.js";
 
 /**
+ * Auth configuration for fetching the OpenAPI spec.
+ * Currently only supports Basic Auth.
+ */
+export interface FetchAuthConfig {
+  /** Auth type — only "basic" is supported */
+  type: "basic";
+  /** Username (supports $VAR env var interpolation) */
+  username?: string;
+  /** Password (supports $VAR env var interpolation) */
+  password?: string;
+}
+
+/**
  * Fetch configuration for remote spec retrieval.
  */
 export interface FetchConfig {
   /** Headers to include when fetching the OpenAPI spec */
   headers?: Record<string, string>;
+  /** Auth configuration for spec endpoint */
+  auth?: FetchAuthConfig;
 }
 
 /**
@@ -129,6 +144,11 @@ token_key = "${config.instance.token_key}"
 auth_mode = "${config.instance.auth_mode}"
 with_credentials = ${config.instance.with_credentials}
 timeout = ${config.instance.timeout}
+
+# [fetch.auth]
+# type = "basic"
+# username = "$SWAGGER_USER"
+# password = "$SWAGGER_PASS"
 
 [watch]
 debug = ${config.watch.debug}
@@ -338,6 +358,40 @@ function validateConfig(config: unknown): ApiConfig {
 }
 
 /**
+ * Validates the fetch auth configuration section.
+ */
+function validateFetchAuthConfig(auth: unknown): FetchAuthConfig | undefined {
+  if (auth === undefined || auth === null) {
+    return;
+  }
+
+  if (typeof auth !== "object") {
+    throw new ConfigValidationError("fetch.auth", "fetch.auth must be an object");
+  }
+
+  const authObj = auth as Record<string, unknown>;
+
+  if (typeof authObj.type !== "string" || authObj.type !== "basic") {
+    throw new ConfigValidationError(
+      "fetch.auth.type",
+      'fetch.auth.type must be "basic"'
+    );
+  }
+
+  const username =
+    typeof authObj.username === "string" && authObj.username.trim().length > 0
+      ? authObj.username
+      : undefined;
+
+  const password =
+    typeof authObj.password === "string" && authObj.password.trim().length > 0
+      ? authObj.password
+      : undefined;
+
+  return { type: "basic", username, password };
+}
+
+/**
  * Validates the fetch configuration section.
  */
 function validateFetchConfig(fetch: unknown): FetchConfig | undefined {
@@ -376,7 +430,14 @@ function validateFetchConfig(fetch: unknown): FetchConfig | undefined {
     }
   }
 
-  return headers ? { headers } : undefined;
+  // Validate auth if provided
+  const auth = validateFetchAuthConfig(fetchObj.auth);
+
+  if (!headers && !auth) {
+    return;
+  }
+
+  return { ...(headers ? { headers } : {}), ...(auth ? { auth } : {}) };
 }
 
 /**

--- a/src/core/fetcher.ts
+++ b/src/core/fetcher.ts
@@ -160,6 +160,7 @@ export async function fetchOpenApiSpec(options: {
 	force?: boolean;
 	retryConfig?: RetryConfig;
 	headers?: Record<string, string>;
+	auth?: { username: string; password: string };
 }): Promise<FetchResult> {
 	const { endpoint, specPath, cachePath, logger, force = false } = options;
 	const retryConfig = options.retryConfig ?? DEFAULT_RETRY_CONFIG;
@@ -177,6 +178,14 @@ export async function fetchOpenApiSpec(options: {
 				`Failed to interpolate headers: ${error instanceof Error ? error.message : String(error)}`
 			);
 		}
+	}
+
+	// Apply Basic Auth if provided (takes precedence over any Authorization header)
+	if (options.auth) {
+		const credentials = Buffer.from(
+			`${options.auth.username}:${options.auth.password}`
+		).toString("base64");
+		headers["Authorization"] = `Basic ${credentials}`;
 	}
 
 	// Load existing cache metadata

--- a/src/core/fetcher.ts
+++ b/src/core/fetcher.ts
@@ -185,6 +185,12 @@ export async function fetchOpenApiSpec(options: {
 		const credentials = Buffer.from(
 			`${options.auth.username}:${options.auth.password}`
 		).toString("base64");
+		// Remove any existing Authorization header (case-insensitive) to avoid duplicates
+		for (const key of Object.keys(headers)) {
+			if (key.toLowerCase() === "authorization") {
+				delete headers[key];
+			}
+		}
 		headers["Authorization"] = `Basic ${credentials}`;
 	}
 

--- a/src/headless/runner.ts
+++ b/src/headless/runner.ts
@@ -240,7 +240,10 @@ async function handleFetch(args: string[]): Promise<void> {
 	};
 
 	try {
-		const prompts = createHeadlessPromptProvider();
+		const prompts =
+			process.stdin.isTTY && process.stdout.isTTY
+				? createHeadlessPromptProvider()
+				: undefined;
 		const result = await executeFetch(options, logger, prompts);
 		if (!result.specChanged && !values.quiet) {
 			logger.info("Spec unchanged, nothing to do. Use --force to regenerate.");

--- a/src/headless/runner.ts
+++ b/src/headless/runner.ts
@@ -193,6 +193,10 @@ function createHeadlessPromptProvider(): PromptProvider {
 			const { confirm } = await import("@inquirer/prompts");
 			return confirm(opts);
 		},
+		async password(opts) {
+			const { password } = await import("@inquirer/prompts");
+			return password({ message: opts.message, mask: opts.mask });
+		},
 		async checkbox(opts) {
 			const { checkbox } = await import("@inquirer/prompts");
 			return checkbox(opts);
@@ -236,7 +240,8 @@ async function handleFetch(args: string[]): Promise<void> {
 	};
 
 	try {
-		const result = await executeFetch(options, logger);
+		const prompts = createHeadlessPromptProvider();
+		const result = await executeFetch(options, logger, prompts);
 		if (!result.specChanged && !values.quiet) {
 			logger.info("Spec unchanged, nothing to do. Use --force to regenerate.");
 		}

--- a/src/tui/screens/fetch-generate.tsx
+++ b/src/tui/screens/fetch-generate.tsx
@@ -10,10 +10,12 @@ import {
 	executeFetch,
 	type FetchActionResult,
 } from "../../core/actions/fetch.js";
+import { loadConfig } from "../../core/config.js";
+import { interpolateEnvVars } from "../../core/fetcher.js";
 import { createTuiLogger, type LogEntry } from "../adapters/tui-logger.js";
 import { formatDuration } from "../../adapters/logger-interface.js";
 
-type Phase = "idle" | "running" | "done" | "error";
+type Phase = "idle" | "auth-username" | "auth-password" | "running" | "done" | "error";
 
 export function FetchGenerateScreen() {
 	const [phase, setPhase] = useState<Phase>("idle");
@@ -21,51 +23,120 @@ export function FetchGenerateScreen() {
 	const [result, setResult] = useState<FetchActionResult | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [force, setForce] = useState(false);
+	const [usernameDraft, setUsernameDraft] = useState("");
+	const [passwordDraft, setPasswordDraft] = useState("");
+	const [resolvedUsername, setResolvedUsername] = useState<string | undefined>();
 	const forceRef = useRef(false);
 	forceRef.current = force;
 	const runningRef = useRef(false);
 
+	const executeFetchWithAuth = useCallback(
+		(auth?: { username: string; password: string }) => {
+			setPhase("running");
+			setLogs([]);
+			setResult(null);
+			setError(null);
+
+			const { logger, getLogs } = createTuiLogger("info");
+
+			const logInterval = setInterval(() => {
+				setLogs(getLogs());
+			}, 200);
+
+			executeFetch(
+				{
+					force: forceRef.current,
+					dryRun: false,
+					typesOnly: false,
+					operationsOnly: false,
+					auth,
+				},
+				logger,
+			)
+				.then((res) => {
+					clearInterval(logInterval);
+					setLogs(getLogs());
+					setResult(res);
+					setPhase("done");
+				})
+				.catch((e: unknown) => {
+					clearInterval(logInterval);
+					setLogs(getLogs());
+					const msg = e instanceof Error ? e.message : String(e);
+					setError(msg);
+					setPhase("error");
+				})
+				.finally(() => {
+					runningRef.current = false;
+					setUsernameDraft("");
+					setPasswordDraft("");
+					setResolvedUsername(undefined);
+				});
+		},
+		[],
+	);
+
 	const runFetch = useCallback(() => {
 		if (runningRef.current) return;
 		runningRef.current = true;
-		setPhase("running");
-		setLogs([]);
-		setResult(null);
-		setError(null);
 
-		const { logger, getLogs } = createTuiLogger("info");
+		// Check config for auth requirements before fetching
+		loadConfig()
+			.then(({ config }) => {
+				const authCfg = config.fetch?.auth;
+				if (authCfg?.type !== "basic") {
+					executeFetchWithAuth(undefined);
+					return;
+				}
 
-		// Poll logs while running
-		const logInterval = setInterval(() => {
-			setLogs(getLogs());
-		}, 200);
+				// Try env var resolution first
+				let username: string | undefined;
+				let password: string | undefined;
+				if (authCfg.username) {
+					try {
+						username = interpolateEnvVars(authCfg.username);
+					} catch {
+						// fall through to prompt
+					}
+				}
+				if (authCfg.password) {
+					try {
+						password = interpolateEnvVars(authCfg.password);
+					} catch {
+						// fall through to prompt
+					}
+				}
 
-		executeFetch(
-			{
-				force: forceRef.current,
-				dryRun: false,
-				typesOnly: false,
-				operationsOnly: false,
-			},
-			logger,
-		)
-			.then((res) => {
-				clearInterval(logInterval);
-				setLogs(getLogs());
-				setResult(res);
-				setPhase("done");
+				if (username && password) {
+					executeFetchWithAuth({ username, password });
+					return;
+				}
+
+				// Need interactive prompts — enter auth phase
+				if (username) setResolvedUsername(username);
+				setPhase(username ? "auth-password" : "auth-username");
+				runningRef.current = false;
 			})
 			.catch((e: unknown) => {
-				clearInterval(logInterval);
-				setLogs(getLogs());
 				const msg = e instanceof Error ? e.message : String(e);
 				setError(msg);
 				setPhase("error");
-			})
-			.finally(() => {
 				runningRef.current = false;
 			});
-	}, []);
+	}, [executeFetchWithAuth]);
+
+	const handleUsernameSubmit = useCallback(() => {
+		if (!usernameDraft.trim()) return;
+		setResolvedUsername(usernameDraft.trim());
+		setPhase("auth-password");
+	}, [usernameDraft]);
+
+	const handlePasswordSubmit = useCallback(() => {
+		if (!passwordDraft) return;
+		const username = resolvedUsername ?? usernameDraft.trim();
+		runningRef.current = true;
+		executeFetchWithAuth({ username, password: passwordDraft });
+	}, [passwordDraft, resolvedUsername, usernameDraft, executeFetchWithAuth]);
 
 	useKeyboard((key) => {
 		if (phase === "idle" || phase === "done" || phase === "error") {
@@ -73,6 +144,14 @@ export function FetchGenerateScreen() {
 				runFetch();
 			} else if (key.raw === "f") {
 				setForce((prev) => !prev);
+			}
+		} else if (phase === "auth-username" || phase === "auth-password") {
+			if (key.name === "escape") {
+				setPhase("idle");
+				setUsernameDraft("");
+				setPasswordDraft("");
+				setResolvedUsername(undefined);
+				runningRef.current = false;
 			}
 		}
 	});
@@ -99,6 +178,40 @@ export function FetchGenerateScreen() {
 							{force ? "ON" : "OFF"}
 						</text>
 					</box>
+				</box>
+			)}
+
+			{phase === "auth-username" && (
+				<box flexDirection="column" gap={1} paddingX={1}>
+					<text fg={colors.accent}>{"Basic Auth Required"}</text>
+					<text fg={colors.fgDim}>
+						{"The spec endpoint requires Basic Auth. Enter your credentials."}
+					</text>
+					<text fg={colors.fg}>{"Username:"}</text>
+					<input
+						value={usernameDraft}
+						onInput={setUsernameDraft}
+						onSubmit={handleUsernameSubmit}
+						focused={true}
+					/>
+					<text fg={colors.fgDim}>{"Enter continue | Esc cancel"}</text>
+				</box>
+			)}
+
+			{phase === "auth-password" && (
+				<box flexDirection="column" gap={1} paddingX={1}>
+					<text fg={colors.accent}>{"Basic Auth Required"}</text>
+					<text fg={colors.fgDim}>
+						{`Username: ${resolvedUsername ?? usernameDraft}`}
+					</text>
+					<text fg={colors.fg}>{"Password:"}</text>
+					<input
+						value={passwordDraft}
+						onInput={setPasswordDraft}
+						onSubmit={handlePasswordSubmit}
+						focused={true}
+					/>
+					<text fg={colors.fgDim}>{"Enter continue | Esc cancel"}</text>
 				</box>
 			)}
 

--- a/src/tui/screens/init-wizard.tsx
+++ b/src/tui/screens/init-wizard.tsx
@@ -138,6 +138,9 @@ function buildReplayProvider(values: WizardValues): PromptProvider {
 			// Unknown confirms -- use whatever the safe default is
 			return opts.default ?? false;
 		},
+		password: async () => {
+			return "";
+		},
 		checkbox: async (opts) => {
 			// Auto-select all available scripts for concurrent setup
 			return opts.choices.map((c) => c.value) as never;

--- a/src/tui/screens/plugins-manager.tsx
+++ b/src/tui/screens/plugins-manager.tsx
@@ -162,6 +162,9 @@ function buildSetupReplayProvider(values: SetupValues): PromptProvider {
 		async confirm() {
 			return true;
 		},
+		async password() {
+			return "";
+		},
 		async checkbox() {
 			return [];
 		},


### PR DESCRIPTION
## Summary

Adds first-class Basic Auth support for fetching OpenAPI specs from auth-protected Swagger endpoints. Previously, `chowbea-axios fetch` failed with 401 when the spec URL required credentials. Now a new optional `[fetch.auth]` config section accepts `type = "basic"` with `username`/`password` fields that support `$ENV_VAR` interpolation. If credentials are missing at fetch time, the headless CLI prompts interactively via a new `password()` method on `PromptProvider`; non-interactive contexts throw a clear error. A design spec is included under `docs/superpowers/specs/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Basic Authentication support for OpenAPI specification fetching
  * Password masking for interactive credential prompts
  * Configuration now supports `[fetch.auth]` section with username/password and environment variable interpolation
  * Non-interactive mode provides clear error messaging when credentials are missing

* **Documentation**
  * Added specification for Basic Authentication design and implementation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->