### PR TITLE
fix(config): wire spec_file through validator, generate, watch, diff, init

### DIFF
--- a/src/core/actions/diff.ts
+++ b/src/core/actions/diff.ts
@@ -8,6 +8,7 @@ import {
 	ensureOutputFolder,
 	getOutputPaths,
 	loadConfig,
+	resolveSpecSource,
 } from "../config.js";
 import { formatError, SpecNotFoundError } from "../errors.js";
 import {
@@ -144,21 +145,27 @@ export async function executeDiff(
 		let newSpec: unknown;
 		let newHash: string;
 
-		if (options.specFile) {
-			// Load from provided file
-			const result = await loadLocalSpec(options.specFile);
+		const specSource = resolveSpecSource(
+			config,
+			projectRoot,
+			options.specFile,
+		);
+
+		if (specSource.type === "local") {
+			// Load from local path (CLI flag or config.spec_file)
+			const result = await loadLocalSpec(specSource.path);
 			newSpec = result.spec;
 			newHash = computeHash(result.buffer);
-			logger.info({ spec: options.specFile }, "Loaded new spec from file");
+			logger.info({ spec: specSource.path }, "Loaded new spec from file");
 		} else {
 			// Fetch from remote
 			logger.info(
-				{ endpoint: config.api_endpoint },
+				{ endpoint: specSource.endpoint },
 				"Fetching new spec from endpoint..."
 			);
 
 			const fetchResult = await fetchOpenApiSpec({
-				endpoint: config.api_endpoint,
+				endpoint: specSource.endpoint,
 				specPath: outputPaths.spec,
 				cachePath: outputPaths.cache,
 				logger,

--- a/src/core/actions/generate.ts
+++ b/src/core/actions/generate.ts
@@ -99,32 +99,33 @@ export async function executeGenerate(
 	await ensureOutputFolders(outputPaths);
 	logger.debug({ folder: outputPaths.folder }, "Output folders ready");
 
-	// Handle --spec-file flag: copy local spec to cache location
-	if (options.specFile) {
-		const specSource = resolveSpecSource(config, projectRoot, options.specFile);
-		if (specSource.type === "local") {
-			logger.info(
-				{ specFile: specSource.path },
-				"Loading local spec file...",
-			);
+	// Resolve spec source — honors both --spec-file CLI flag AND config.spec_file
+	// (priority: flag > config.spec_file > config.api_endpoint, per resolveSpecSource).
+	// For local sources, copy into the cache location so the rest of the pipeline
+	// reads from a consistent place.
+	const specSource = resolveSpecSource(config, projectRoot, options.specFile);
+	if (specSource.type === "local") {
+		logger.info(
+			{ specFile: specSource.path },
+			"Loading local spec file...",
+		);
 
-			// Load and validate the spec
-			const { buffer } = await loadLocalSpec(specSource.path);
-			const hash = computeHash(buffer);
+		// Load and validate the spec
+		const { buffer } = await loadLocalSpec(specSource.path);
+		const hash = computeHash(buffer);
 
-			// Copy to cache location
-			await writeFile(outputPaths.spec, buffer);
-			await saveCacheMetadata(outputPaths.cache, {
-				hash,
-				timestamp: Date.now(),
-				endpoint: specSource.path,
-			});
+		// Copy to cache location
+		await writeFile(outputPaths.spec, buffer);
+		await saveCacheMetadata(outputPaths.cache, {
+			hash,
+			timestamp: Date.now(),
+			endpoint: specSource.path,
+		});
 
-			logger.info(
-				{ bytes: buffer.length, hash: hash.slice(0, 8) },
-				"Spec copied to cache",
-			);
-		}
+		logger.info(
+			{ bytes: buffer.length, hash: hash.slice(0, 8) },
+			"Spec copied to cache",
+		);
 	}
 
 	// Check if local spec exists

--- a/src/core/actions/init.ts
+++ b/src/core/actions/init.ts
@@ -201,11 +201,19 @@ export async function hasFile(
  * Creates api.config.toml if it doesn't exist or if user confirms overwrite.
  * Returns true when the file was (over)written.
  */
+/**
+ * Returns true if the given string looks like a remote URL (has a
+ * http/https/ftp scheme). Otherwise it's treated as a local file path.
+ */
+function isRemoteSpecUrl(value: string): boolean {
+  return /^(https?|ftp):\/\//i.test(value.trim());
+}
+
 async function setupConfig(
   projectRoot: string,
   force: boolean,
   instanceConfig: InstanceConfig,
-  apiEndpoint: string,
+  specSource: { kind: "remote"; endpoint: string } | { kind: "local"; specFile: string },
   outputFolder: string,
   logger: Logger,
   prompts: PromptProvider,
@@ -232,7 +240,10 @@ async function setupConfig(
   }
 
   const configContent = generateConfigTemplate({
-    api_endpoint: apiEndpoint,
+    api_endpoint:
+      specSource.kind === "remote" ? specSource.endpoint : undefined,
+    spec_file:
+      specSource.kind === "local" ? specSource.specFile : undefined,
     poll_interval_ms: 10_000,
     output: { folder: outputFolder },
     instance: instanceConfig,
@@ -1002,13 +1013,22 @@ export async function executeInit(
     }
   }
 
-  // Prompt for API endpoint URL
-  const apiEndpoint = await prompts.input({
-    message: "Enter your OpenAPI spec endpoint URL:",
+  // Prompt for spec source — accepts either a remote URL or a local file path.
+  // The answer is auto-classified by shape: http(s)://... → remote endpoint;
+  // anything else → local file path (spec_file in config).
+  const specInput = await prompts.input({
+    message:
+      "Enter your OpenAPI spec URL (http://...) or local file path (./openapi.json):",
     default: DEFAULT_CONFIG.api_endpoint,
     validate: (value) =>
-      value.trim().length > 0 ? true : "API endpoint URL is required",
+      value.trim().length > 0
+        ? true
+        : "A spec URL or local file path is required",
   });
+  const specSource: { kind: "remote"; endpoint: string } | { kind: "local"; specFile: string } =
+    isRemoteSpecUrl(specInput)
+      ? { kind: "remote", endpoint: specInput.trim() }
+      : { kind: "local", specFile: specInput.trim() };
 
   // Prompt for output folder location
   const outputFolder = await prompts.input({
@@ -1089,7 +1109,7 @@ export async function executeInit(
     projectRoot,
     options.force,
     instanceConfig,
-    apiEndpoint,
+    specSource,
     outputFolder,
     logger,
     prompts,
@@ -1183,9 +1203,14 @@ export async function executeInit(
   // Step 6: Ensure _internal/ is in .gitignore
   await ensureGitignoreEntries(projectRoot, logger);
 
-  // Step 7: Run initial fetch (if not localhost default)
+  // Step 7: Run initial fetch.
+  // - Local spec_file: always safe to read, always run.
+  // - Remote localhost: skip (user's dev server may not be running yet).
+  // - Remote non-localhost: run.
   const isLocalhost =
-    apiEndpoint.includes("localhost") || apiEndpoint.includes("127.0.0.1");
+    specSource.kind === "remote" &&
+    (specSource.endpoint.includes("localhost") ||
+      specSource.endpoint.includes("127.0.0.1"));
   let initialFetchSuccess: boolean | null = null;
   if (!isLocalhost) {
     initialFetchSuccess = await runInitialFetch(projectRoot, pm, logger);

--- a/src/core/actions/status.ts
+++ b/src/core/actions/status.ts
@@ -43,7 +43,10 @@ export type FileStatus = Record<string, { exists: boolean; modifiedAgo?: string 
 export interface StatusResult {
 	configPath: string;
 	wasCreated: boolean;
+	/** Remote URL or local spec file path — whichever is configured. */
 	endpoint: string;
+	/** True when `endpoint` is a local spec_file path rather than a remote URL. */
+	isLocalSpec: boolean;
 	outputFolder: string;
 	cacheMetadata: CacheMetadata | null;
 	specExists: boolean;
@@ -164,10 +167,17 @@ export async function executeStatus(
 			: null;
 		const fileStatus = await checkGeneratedFiles(outputPaths);
 
+		// Resolve displayed source: prefer local spec_file when set, else api_endpoint.
+		const isLocalSpec = Boolean(config.spec_file);
+		const endpoint = isLocalSpec
+			? (config.spec_file as string)
+			: (config.api_endpoint ?? "");
+
 		return {
 			configPath: path.relative(projectRoot, configPath),
 			wasCreated,
-			endpoint: config.api_endpoint,
+			endpoint,
+			isLocalSpec,
 			outputFolder: config.output.folder,
 			cacheMetadata,
 			specExists,

--- a/src/core/actions/watch.ts
+++ b/src/core/actions/watch.ts
@@ -12,8 +12,16 @@ import {
 	ensureOutputFolders,
 	getOutputPaths,
 	loadConfig,
+	resolveSpecSource,
+	type SpecSource,
 } from "../config.js";
-import { fetchOpenApiSpec, saveSpec } from "../fetcher.js";
+import {
+	computeHash,
+	fetchOpenApiSpec,
+	loadCacheMetadata,
+	loadLocalSpec,
+	saveSpec,
+} from "../fetcher.js";
 import { generate, generateClientFiles } from "../generator.js";
 
 /**
@@ -120,12 +128,12 @@ export async function executeWatch(
 		logger,
 	});
 
-	// Determine polling interval
+	// Determine polling interval and spec source (local file or remote endpoint)
 	const intervalMs = options.intervalMs ?? config.poll_interval_ms;
-	const endpoint = config.api_endpoint;
+	const specSource = resolveSpecSource(config, projectRoot);
 
 	logger.step("watch", "Starting watch mode...");
-	logger.debug({ endpoint, intervalMs }, "config");
+	logger.debug({ specSource, intervalMs }, "config");
 
 	let cycleCounter = 0;
 	const signal = options.signal;
@@ -137,7 +145,7 @@ export async function executeWatch(
 
 		await runCycle({
 			cycleId,
-			endpoint,
+			specSource,
 			outputPaths,
 			logger,
 			headers: config.fetch?.headers,
@@ -157,17 +165,19 @@ export async function executeWatch(
 }
 
 /**
- * Runs a single watch cycle - fetch, check for changes, regenerate if needed.
+ * Runs a single watch cycle - load (fetch or read) the spec, check for changes,
+ * regenerate if needed.
  */
 async function runCycle(options: {
 	cycleId: number;
-	endpoint: string;
+	specSource: SpecSource;
 	outputPaths: ReturnType<typeof getOutputPaths>;
 	logger: Logger;
 	headers?: Record<string, string>;
 	callbacks?: WatchCallbacks;
 }): Promise<void> {
-	const { cycleId, endpoint, outputPaths, logger, headers, callbacks } = options;
+	const { cycleId, specSource, outputPaths, logger, headers, callbacks } =
+		options;
 	const startTime = Date.now();
 
 	// Notify cycle start
@@ -179,25 +189,49 @@ async function runCycle(options: {
 	}
 
 	try {
-		// Fetch the spec with retry logic (debug level - only shown with --debug)
-		logger.debug({ cycleId, endpoint }, "Checking for API changes...");
+		let newBuffer: Buffer;
+		let newHash: string;
+		let sourceIdentifier: string;
+		let hasChanged: boolean;
 
-		const fetchResult = await fetchOpenApiSpec({
-			endpoint,
-			specPath: outputPaths.spec,
-			cachePath: outputPaths.cache,
-			logger,
-			force: false,
-			headers,
-		});
+		if (specSource.type === "local") {
+			// Local file mode — hash file contents and compare against cache
+			sourceIdentifier = specSource.path;
+			logger.debug({ cycleId, path: specSource.path }, "Checking local spec...");
+			const { buffer } = await loadLocalSpec(specSource.path);
+			newBuffer = buffer;
+			newHash = computeHash(buffer);
 
-		// Handle network fallback
-		if (fetchResult.fromCache) {
-			logger.warn({ cycleId }, "Using cached spec due to network issues");
+			// Compare against previously-saved spec hash
+			const existingCache = await loadCacheMetadata(outputPaths.cache);
+			hasChanged = existingCache?.hash !== newHash;
+		} else {
+			// Remote mode — fetch with retry
+			sourceIdentifier = specSource.endpoint;
+			logger.debug(
+				{ cycleId, endpoint: specSource.endpoint },
+				"Checking for API changes...",
+			);
+			const fetchResult = await fetchOpenApiSpec({
+				endpoint: specSource.endpoint,
+				specPath: outputPaths.spec,
+				cachePath: outputPaths.cache,
+				logger,
+				force: false,
+				headers,
+			});
+
+			if (fetchResult.fromCache) {
+				logger.warn({ cycleId }, "Using cached spec due to network issues");
+			}
+
+			newBuffer = fetchResult.buffer;
+			newHash = fetchResult.hash;
+			hasChanged = fetchResult.hasChanged;
 		}
 
 		// Skip if unchanged (debug level - only shown with --debug)
-		if (!fetchResult.hasChanged) {
+		if (!hasChanged) {
 			const durationMs = Date.now() - startTime;
 			logger.debug(
 				{ cycleId, durationMs: formatDuration(durationMs) },
@@ -209,15 +243,15 @@ async function runCycle(options: {
 
 		// Save the new spec
 		await saveSpec({
-			buffer: fetchResult.buffer,
-			hash: fetchResult.hash,
-			endpoint,
+			buffer: newBuffer,
+			hash: newHash,
+			endpoint: sourceIdentifier,
 			specPath: outputPaths.spec,
 			cachePath: outputPaths.cache,
 		});
 
 		logger.info(
-			{ cycleId, bytes: fetchResult.buffer.length },
+			{ cycleId, bytes: newBuffer.length },
 			"New spec detected, regenerating...",
 		);
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -70,8 +70,8 @@ export interface InstanceConfig {
  * Configuration structure for api.config.toml
  */
 export interface ApiConfig {
-  /** Remote OpenAPI spec endpoint URL */
-  api_endpoint: string;
+  /** Remote OpenAPI spec endpoint URL. Optional when `spec_file` is set. */
+  api_endpoint?: string;
   /** Local spec file path (takes priority over api_endpoint if set) */
   spec_file?: string;
   /** Polling interval in milliseconds for watch mode */
@@ -128,10 +128,17 @@ export const DEFAULT_CONFIG: ApiConfig = {
  * Single source of truth — used by both auto-create and init command.
  */
 export function generateConfigTemplate(config: ApiConfig): string {
+  // Emit whichever spec source is configured as the active line, and the
+  // other as a commented-out example.
+  const specSourceBlock = config.spec_file
+    ? `# api_endpoint = "${config.api_endpoint ?? "https://api.example.com/openapi.json"}"  # Use remote endpoint instead of local file
+spec_file = "${config.spec_file}"`
+    : `api_endpoint = "${config.api_endpoint}"
+# spec_file = "./openapi.json"  # Use local file instead of remote`;
+
   return `# Chowbea Axios Configuration
 
-api_endpoint = "${config.api_endpoint}"
-# spec_file = "./openapi.json"  # Use local file instead of remote
+${specSourceBlock}
 poll_interval_ms = ${config.poll_interval_ms}
 
 [output]
@@ -296,14 +303,25 @@ function validateConfig(config: unknown): ApiConfig {
 
   const cfg = config as Record<string, unknown>;
 
-  // Validate api_endpoint
-  if (
-    typeof cfg.api_endpoint !== "string" ||
-    cfg.api_endpoint.trim().length === 0
-  ) {
+  // Validate spec source: at least one of api_endpoint or spec_file must be set.
+  // spec_file takes priority at resolve time (see resolveSpecSource), so
+  // api_endpoint is only required when spec_file is absent.
+  const hasSpecFile =
+    typeof cfg.spec_file === "string" && cfg.spec_file.trim().length > 0;
+  const hasApiEndpoint =
+    typeof cfg.api_endpoint === "string" &&
+    cfg.api_endpoint.trim().length > 0;
+
+  if (!hasSpecFile && !hasApiEndpoint) {
     throw new ConfigValidationError(
       "api_endpoint",
-      "api_endpoint must be a non-empty string URL"
+      "Configuration must set either api_endpoint (remote URL) or spec_file (local path)"
+    );
+  }
+  if (cfg.api_endpoint !== undefined && !hasApiEndpoint) {
+    throw new ConfigValidationError(
+      "api_endpoint",
+      "api_endpoint must be a non-empty string URL when provided"
     );
   }
 
@@ -345,7 +363,7 @@ function validateConfig(config: unknown): ApiConfig {
   const watch = validateWatchConfig(cfg.watch);
 
   return {
-    api_endpoint: cfg.api_endpoint,
+    api_endpoint: hasApiEndpoint ? (cfg.api_endpoint as string) : undefined,
     spec_file,
     poll_interval_ms: cfg.poll_interval_ms,
     output: {
@@ -472,7 +490,13 @@ export function resolveSpecSource(
     return { type: "local", path: resolvedPath };
   }
 
-  // Default to remote endpoint
+  // Default to remote endpoint. Validator guarantees api_endpoint is present
+  // whenever spec_file is absent, but we guard here for defense-in-depth.
+  if (!config.api_endpoint) {
+    throw new Error(
+      "No spec source configured: set either api_endpoint or spec_file in api.config.toml"
+    );
+  }
   return { type: "remote", endpoint: config.api_endpoint };
 }
 

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -84,7 +84,7 @@ export class SpecNotFoundError extends ChowbeaAxiosError {
 		super(
 			`OpenAPI spec not found at: ${specPath}`,
 			"SPEC_NOT_FOUND",
-			"Run 'chowbea-axios fetch' to download the spec from the remote endpoint."
+			"Run 'chowbea-axios fetch' to load the spec (from api_endpoint or spec_file in api.config.toml)."
 		);
 		this.name = "SpecNotFoundError";
 		this.specPath = specPath;

--- a/src/tui/screens/init-wizard.tsx
+++ b/src/tui/screens/init-wizard.tsx
@@ -83,9 +83,19 @@ const STEPS = [
 // Helper: build TOML preview from wizard values
 // ---------------------------------------------------------------------------
 
+/**
+ * True if the input looks like a remote URL (has an http/https/ftp scheme).
+ * Otherwise it's treated as a local file path (spec_file in config).
+ */
+function isRemoteSpecUrl(value: string): boolean {
+	return /^(https?|ftp):\/\//i.test(value.trim());
+}
+
 function buildPreviewConfig(values: WizardValues): string {
+	const isRemote = isRemoteSpecUrl(values.endpoint);
 	const config: ApiConfig = {
-		api_endpoint: values.endpoint,
+		api_endpoint: isRemote ? values.endpoint : undefined,
+		spec_file: isRemote ? undefined : values.endpoint,
 		poll_interval_ms: DEFAULT_CONFIG.poll_interval_ms,
 		output: { folder: values.outputFolder },
 		instance: {
@@ -104,7 +114,14 @@ function buildPreviewConfig(values: WizardValues): string {
 function buildReplayProvider(values: WizardValues): PromptProvider {
 	return {
 		input: async (opts) => {
-			if (opts.message.includes("endpoint")) return values.endpoint;
+			// Match both the legacy "endpoint" prompt and the new
+			// "spec URL or local file path" prompt used by init.ts.
+			if (
+				opts.message.includes("endpoint") ||
+				opts.message.includes("spec URL") ||
+				opts.message.includes("OpenAPI spec")
+			)
+				return values.endpoint;
 			if (
 				opts.message.includes("placed") ||
 				opts.message.includes("folder")
@@ -229,7 +246,7 @@ function WizardMode({ onComplete, setInputMode }: WizardModeProps) {
 	// Wizard state
 	const [step, setStep] = useState(0);
 	const [values, setValues] = useState<WizardValues>({
-		endpoint: DEFAULT_CONFIG.api_endpoint,
+		endpoint: DEFAULT_CONFIG.api_endpoint ?? "",
 		outputFolder: DEFAULT_CONFIG.output.folder,
 		pm: "npm", // updated by auto-detection below
 		authMode: "custom",
@@ -423,7 +440,7 @@ function WizardMode({ onComplete, setInputMode }: WizardModeProps) {
 	const handleEndpointSubmit = useCallback(
 		(valOrEvent: unknown) => {
 			const val = typeof valOrEvent === "string" ? valOrEvent : "";
-			const trimmed = val.trim() || DEFAULT_CONFIG.api_endpoint;
+			const trimmed = val.trim() || DEFAULT_CONFIG.api_endpoint || "";
 			setValues((v) => ({ ...v, endpoint: trimmed }));
 			setEndpointDraft(trimmed);
 			setStep(1);
@@ -480,12 +497,12 @@ function WizardMode({ onComplete, setInputMode }: WizardModeProps) {
 				</text>
 			</box>
 
-			{/* Step 0: API Endpoint */}
+			{/* Step 0: API Endpoint or Local File */}
 			{phase === "wizard" && step === 0 && (
 				<box flexDirection="column" gap={1} paddingX={1}>
-					<text fg={colors.accent}>{"API Endpoint"}</text>
+					<text fg={colors.accent}>{"OpenAPI Spec Source"}</text>
 					<text fg={colors.fgDim}>
-						{"Enter the URL to your OpenAPI spec (JSON or YAML)"}
+						{"URL (http://…/openapi.json) or local file path (./openapi.json)"}
 					</text>
 					<input
 						placeholder={DEFAULT_CONFIG.api_endpoint}


### PR DESCRIPTION
## Summary

Closes #7, closes #8.

Previously `spec_file` in `api.config.toml` was only wired into `fetch`. Every other command required an `api_endpoint` URL, even when the user had configured a local spec. The inline TOML comment literally says *"Use local file instead of remote"*, but flipping the config as the comment suggests hit a validator error immediately.

This PR finishes the wiring across all commands and the init wizard.

## Before

Try to use a local-only config:

```toml
spec_file = "./openapi.json"
poll_interval_ms = 10000
[output]
folder = "src/api"
```

```bash
$ chowbea-axios generate
✗ error  Error [CONFIG_VALIDATION_ERROR]: api_endpoint must be a non-empty string URL
```

Even with a placeholder `api_endpoint` bolted on:

```bash
$ chowbea-axios generate
✗ error  Error [SPEC_NOT_FOUND]: OpenAPI spec not found at: .../src/api/_internal/openapi.json
  Recovery: Run 'chowbea-axios fetch' to download the spec from the remote endpoint.
```

## After

```toml
spec_file = "./openapi.json"
```

```bash
$ chowbea-axios generate
✓ Loading local spec file...
✓ Generation completed — 5 operations
```

`fetch`, `status`, `watch`, `diff`, and `init` all understand local spec files. The wizard's first prompt now reads *"URL or local file path"* and auto-classifies by `http(s)://` prefix.

## Changes

| File | Change |
| --- | --- |
| `src/core/config.ts` | `api_endpoint` is optional in `ApiConfig`. Validator requires **at least one** of `api_endpoint`/`spec_file`. `resolveSpecSource` defends against both being absent. Template generator emits whichever source is configured as the active line. |
| `src/core/actions/generate.ts` | Always route through `resolveSpecSource` (not just when `--spec-file` flag is passed). Local sources copy to cache before generation. |
| `src/core/actions/watch.ts` | `runCycle` branches on spec source: remote fetches with retry, local hashes file content and regenerates on change. |
| `src/core/actions/diff.ts` | Uses `resolveSpecSource` so diff can compare against a local spec. |
| `src/core/actions/init.ts` | First prompt accepts URL or file path; auto-detects by `http(s)://` prefix. Writes the correct config field. Skips initial remote fetch only for localhost URLs (local specs always run the fetch step since the file is present). |
| `src/tui/screens/init-wizard.tsx` | Mirrors the same detection in the preview TOML. Step 0 help text updated. |
| `src/core/errors.ts` | `SpecNotFoundError` recovery text no longer assumes remote. |
| `src/core/actions/status.ts` | Returns the spec source label (URL or local path) with an `isLocalSpec` flag. |

## Test plan

End-to-end verified against a local spec project (see `.context/test-project/` in the development workspace):

- [x] `pnpm build` — clean
- [x] `api.config.toml` with **only** `spec_file = "./openapi.json"` validates
- [x] `chowbea-axios generate` — 5 operations generated from local file
- [x] `chowbea-axios fetch` — primes cache from local file, no network attempt
- [x] `chowbea-axios status` — displays `./openapi.json` as the source
- [x] `chowbea-axios generate --spec-file <path>` — still honors the CLI flag override
- [x] Remote configs still work — `api_endpoint = "https://..."` path is unchanged

## Interaction with #6

Independent. PR #6 changes the type-surface of generated operations; this PR changes how the spec gets loaded. Both can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for local OpenAPI specification files alongside remote endpoints.
  * Setup wizard now accepts either a URL or local file path as the spec source.
  * Configuration file supports both `api_endpoint` (remote) and `spec_file` (local) options.
  * Status command now displays which spec source is currently in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->