### PR TITLE
fix(cli): visible progress by default, add watch mode heartbeats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chowbea-axios",
-  "version": "2.0.0-alpha.18",
+  "version": "2.0.0-alpha.20",
   "description": "Type-safe axios client with interactive TUI dashboard",
   "type": "module",
   "main": "dist/index.js",

--- a/src/adapters/logger-interface.ts
+++ b/src/adapters/logger-interface.ts
@@ -69,7 +69,11 @@ export const LOG_LEVELS: Record<LogLevel, number> = {
 
 /**
  * Determines log level from CLI flags and config.
- * Priority: quiet > verbose/debug flag > config debug > default (warn)
+ * Priority: quiet > verbose/debug flag > config debug > default (info).
+ *
+ * Default is `info` — users running the CLI without flags should see progress
+ * updates and success messages, not total silence. `warn` is only reached via
+ * the explicit `--quiet`-adjacent path and via `silent`/error handling.
  */
 export function getLogLevel(
 	flags: {
@@ -81,7 +85,7 @@ export function getLogLevel(
 ): LogLevel {
 	if (flags.quiet) return "error";
 	if (flags.verbose || flags.debug || configDebug) return "debug";
-	return "warn";
+	return "info";
 }
 
 /**

--- a/src/core/actions/watch.ts
+++ b/src/core/actions/watch.ts
@@ -124,7 +124,12 @@ export async function executeWatch(
 	const intervalMs = options.intervalMs ?? config.poll_interval_ms;
 	const endpoint = config.api_endpoint;
 
-	logger.step("watch", "Starting watch mode...");
+	// Announce the watch loop at info level so the user knows what's being
+	// polled and at what cadence. In debug mode the full context also fires.
+	logger.step(
+		"watch",
+		`Polling every ${formatDuration(intervalMs)} — ${endpoint}`,
+	);
 	logger.debug({ endpoint, intervalMs }, "config");
 
 	let cycleCounter = 0;
@@ -196,12 +201,13 @@ async function runCycle(options: {
 			logger.warn({ cycleId }, "Using cached spec due to network issues");
 		}
 
-		// Skip if unchanged (debug level - only shown with --debug)
+		// Heartbeat: one line per cycle so watch mode isn't silent when
+		// nothing changes. Compact format so it's tolerable at any interval.
 		if (!fetchResult.hasChanged) {
 			const durationMs = Date.now() - startTime;
-			logger.debug(
-				{ cycleId, durationMs: formatDuration(durationMs) },
-				"No changes detected, skipping generation",
+			logger.info(
+				{ cycle: cycleId, duration: formatDuration(durationMs) },
+				"no changes",
 			);
 			callbacks?.onCycleComplete?.(cycleId, false, durationMs);
 			return;


### PR DESCRIPTION
## Summary

Default log level was `warn`, which silenced every `logger.info()` call — including step announcements like *"Fetching OpenAPI spec..."* and the per-cycle status in watch mode. Running the CLI looked like nothing was happening unless you passed `--verbose`. Watch mode was especially bad: cycle-by-cycle "no changes" was at `debug` level, so the terminal went dead silent for minutes at a time.

## Changes

### `src/adapters/logger-interface.ts`
Default level flipped from `warn` → `info`. `--quiet` still reaches `error`; `--verbose`, `--debug`, and `[watch].debug = true` in `api.config.toml` still reach `debug`.

### `src/core/actions/watch.ts`
- Startup step reworded to announce what's being polled and the cadence:
  ```
  ● watch     Polling every 10.0s — http://localhost:8080/doc/openapi.json
  ```
- "no changes" log promoted from `debug` to `info` with a compact format so the terminal shows a heartbeat every cycle instead of going dead silent.

## Before

```
$ chowbea-axios fetch

  chowbea-axios fetch

$
```

(blank — even though fetch ran successfully)

## After

```
$ chowbea-axios fetch

  chowbea-axios fetch

  ● config    Loading configuration...
  ● fetch     Fetching OpenAPI spec...
              ✓ Spec saved  bytes: 848810, hash: 51afce96
              ✓ Creating api.helpers.ts  path: src/api/api.helpers.ts
              ✓ Creating api.instance.ts  path: src/api/api.instance.ts
              ✓ Creating api.error.ts  path: src/api/api.error.ts
              ✓ Creating api.client.ts  path: src/api/api.client.ts
  ● generate  Generating types and operations...
              ✓ TypeScript types generated successfully
              ✓ Generation completed successfully  operationCount: 935

  ✓ done      Completed in 1.1s - 935 operations
```

### Watch mode heartbeat

```
$ chowbea-axios watch

  chowbea-axios watch

  ● watch     Polling every 10.0s — http://localhost:8080/doc/openapi.json
              ✓ no changes  cycle: 1, duration: 0.2s
              ✓ no changes  cycle: 2, duration: 0.2s
              ✓ New spec detected, regenerating...  cycle: 3, bytes: 848810
              ✓ Generation completed  cycle: 3, operations: 935, duration: 1.1s
              ✓ no changes  cycle: 4, duration: 0.2s
```

## Three-way output volume check

| Invocation | Output |
|---|---|
| `chowbea-axios fetch` | step markers, info messages, completion |
| `chowbea-axios fetch --quiet` | errors only |
| `chowbea-axios fetch --verbose` | all of the above + resolved paths, hashes, full fetch attempt detail |

## Test plan

- [x] `pnpm build` clean
- [x] Default output readable and useful (not spammy)
- [x] `--quiet` suppresses info
- [x] `--verbose` restores full debug detail
- [x] Watch mode shows heartbeats every cycle

## Relationship to open PRs

Independent of #6 (type-surface) and #9 (spec_file config). Branched off `origin/main`, merges cleanly in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Watch mode now shows polling interval and endpoint at startup.
  * Default logging adjusted to be more informative by showing regular progress/success output.
  * Status messages for "no changes" in watch cycles are now concise info-level heartbeats.

* **Chores**
  * Package version bumped to 2.0.0-alpha.20.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->