### PR TITLE
fix(generator): support */* media types and quote dotted property keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chowbea-axios",
-  "version": "2.0.0-alpha.18",
+  "version": "2.0.0-alpha.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chowbea-axios",
-      "version": "2.0.0-alpha.18",
+      "version": "2.0.0-alpha.21",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chowbea-axios",
-  "version": "2.0.0-alpha.20",
+  "version": "2.0.0-alpha.21",
   "description": "Type-safe axios client with interactive TUI dashboard",
   "type": "module",
   "main": "dist/index.js",

--- a/src/core/actions/validate.ts
+++ b/src/core/actions/validate.ts
@@ -15,6 +15,7 @@ import {
 	resolveRef,
 	resolveObject,
 	resolveSchema,
+	pickJsonContent,
 	MAX_SCHEMA_DEPTH,
 } from "../ref-utils.js";
 
@@ -430,9 +431,8 @@ function validateResponses(spec: Record<string, unknown>): CategoryResult {
 					spec,
 				);
 				const content = resp.content as Record<string, unknown> | undefined;
-				if (!content) return false;
-				const json = content["application/json"] as Record<string, unknown> | undefined;
-				return json?.schema !== undefined;
+				const picked = pickJsonContent(content);
+				return picked?.entry?.schema !== undefined;
 			});
 
 			if (!hasJsonSchema) {
@@ -443,7 +443,7 @@ function validateResponses(spec: Record<string, unknown>): CategoryResult {
 					path: opPath,
 					message: streaming
 						? "SSE endpoint — no JSON response schema expected"
-						: "No 2xx response has application/json schema — type generation will produce empty types",
+						: "No 2xx response has a JSON-compatible schema — type generation will produce empty types",
 				});
 			}
 		}
@@ -469,8 +469,8 @@ function validateTypeQuality(spec: Record<string, unknown>): CategoryResult {
 					spec,
 				);
 				const content = resp.content as Record<string, unknown> | undefined;
-				const json = content?.["application/json"] as Record<string, unknown> | undefined;
-				const rawSchema = json?.schema;
+				const picked = pickJsonContent(content);
+				const rawSchema = picked?.entry?.schema;
 
 				if (!rawSchema) continue;
 
@@ -522,9 +522,9 @@ function validateTypeQuality(spec: Record<string, unknown>): CategoryResult {
 			);
 			const content = reqBody.content as Record<string, unknown> | undefined;
 			if (content) {
-				const json = content["application/json"] as Record<string, unknown> | undefined;
+				const picked = pickJsonContent(content);
 				const formData = content["multipart/form-data"] as Record<string, unknown> | undefined;
-				const bodyMedia = json ?? formData;
+				const bodyMedia = picked?.entry ?? formData;
 
 				if (bodyMedia) {
 					const rawSchema = bodyMedia.schema;

--- a/src/core/generator.ts
+++ b/src/core/generator.ts
@@ -532,6 +532,15 @@ function sanitizeIdentifier(name: string): string {
 }
 
 /**
+ * Formats a property name for use as an object-type key. Preserves the original
+ * name when it's a valid unquoted TS identifier; otherwise wraps it in quotes so
+ * names like `hub.mode`, `X-Custom-Header`, or `0.5` remain syntactically valid.
+ */
+function formatPropertyKey(name: string): string {
+	return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name) ? name : JSON.stringify(name);
+}
+
+/**
  * Capitalizes the first letter of a string (for PascalCase conversion from camelCase operationIds).
  */
 function toPascalCase(str: string): string {
@@ -616,7 +625,7 @@ function schemaToTS(
 			const optional = required.has(key) ? "" : "?";
 			const propType = schemaToTS(propSchema, innerIndent, allSchemas, visited);
 			const desc = propSchema.description ? ` /** ${propSchema.description} */\n${innerIndent}` : "";
-			return `${desc}${key}${optional}: ${propType};`;
+			return `${desc}${formatPropertyKey(key)}${optional}: ${propType};`;
 		});
 		return `{\n${innerIndent}${props.join(`\n${innerIndent}`)}\n${indent}}`;
 	}
@@ -740,7 +749,7 @@ function generateContractsFileContent(metadata: ContractMetadata): string {
 						if (propSchema.description) {
 							lines.push(`\t/** ${propSchema.description} */`);
 						}
-						lines.push(`\t${propKey}${optional}: ${propType};`);
+						lines.push(`\t${formatPropertyKey(propKey)}${optional}: ${propType};`);
 					}
 					lines.push(`}`);
 				} else {

--- a/src/core/generator.ts
+++ b/src/core/generator.ts
@@ -17,6 +17,7 @@ import type { InstanceConfig, OutputPaths } from "./config.js";
 import { GenerationError } from "./errors.js";
 import type { Logger } from "../adapters/logger-interface.js";
 import { detectPackageManager, getDlxCommand } from "./pm.js";
+import { pickJsonContent } from "./ref-utils.js";
 
 /**
  * Output paths for generated files.
@@ -228,7 +229,9 @@ function parseOperations(spec: unknown, logger: Logger): OperationMetadata[] {
 					| Record<string, unknown>
 					| undefined;
 				if (content) {
-					if (content["application/json"]) hasJsonBody = true;
+					// Accepts exact `application/json`, json-variant media types, and `*\/*`
+					// as a fallback so Swagger-generated specs type correctly.
+					if (pickJsonContent(content)) hasJsonBody = true;
 					if (content["multipart/form-data"]) hasFormDataBody = true;
 				}
 			}
@@ -255,7 +258,7 @@ function parseOperations(spec: unknown, logger: Logger): OperationMetadata[] {
 					const content = resp.content as
 						| Record<string, unknown>
 						| undefined;
-					if (content && content["application/json"]) {
+					if (pickJsonContent(content)) {
 						responseStatus = statusNum;
 						break;
 					}
@@ -354,7 +357,7 @@ function parseContracts(spec: unknown): ContractMetadata {
 					if (isNaN(statusNum)) continue;
 					const resp = responseObj as Record<string, unknown>;
 					const content = resp.content as Record<string, unknown> | undefined;
-					const hasJsonContent = !!(content && content["application/json"]);
+					const hasJsonContent = !!pickJsonContent(content);
 					const description = typeof resp.description === "string" ? resp.description : "";
 					allResponses.push({ status: statusNum, description, hasJsonContent });
 
@@ -374,7 +377,7 @@ function parseContracts(spec: unknown): ContractMetadata {
 			if (requestBody) {
 				const content = requestBody.content as Record<string, unknown> | undefined;
 				if (content) {
-					if (content["application/json"]) hasJsonBody = true;
+					if (pickJsonContent(content)) hasJsonBody = true;
 					if (content["multipart/form-data"]) hasFormDataBody = true;
 				}
 			}
@@ -657,14 +660,21 @@ function resolveOperationSchema(
 			if (kind === "response" && responseStatus != null) {
 				const responses = op.responses as Record<string, Record<string, unknown>> | undefined;
 				const resp = responses?.[String(responseStatus)];
-				const content = resp?.content as Record<string, Record<string, unknown>> | undefined;
-				return (content?.["application/json"]?.schema as Record<string, unknown>) ?? null;
+				const content = resp?.content as Record<string, unknown> | undefined;
+				const picked = pickJsonContent(content);
+				return (picked?.entry?.schema as Record<string, unknown>) ?? null;
 			}
 
 			if (kind === "requestBody") {
 				const rb = op.requestBody as Record<string, unknown> | undefined;
 				const content = rb?.content as Record<string, Record<string, unknown>> | undefined;
 				const ct = contentType ?? "application/json";
+				// For JSON-ish body lookups, fall back through the media-type priority
+				// so specs using `*\/*` or `application/vnd.api+json` still resolve.
+				if (ct === "application/json") {
+					const picked = pickJsonContent(content as Record<string, unknown> | undefined);
+					return (picked?.entry?.schema as Record<string, unknown>) ?? null;
+				}
 				return (content?.[ct]?.schema as Record<string, unknown>) ?? null;
 			}
 

--- a/src/core/ref-utils.ts
+++ b/src/core/ref-utils.ts
@@ -80,6 +80,42 @@ export function refName(ref: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Media type helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Picks the first usable JSON-ish entry from an OpenAPI `content` map,
+ * preserving spec-author intent via priority order:
+ *   1. Exact `application/json`
+ *   2. Any variant containing `json` (e.g. `application/vnd.api+json`,
+ *      `application/problem+json`, `application/json; charset=utf-8`)
+ *   3. Wildcard `*\/*` as a last resort — common in Swagger-generated specs
+ *      where the backend annotates success responses without a concrete media type
+ */
+export function pickJsonContent(
+	content: Record<string, unknown> | undefined,
+): { mediaType: string; entry: Record<string, unknown> } | null {
+	if (!content) return null;
+	const direct = content["application/json"];
+	if (direct && typeof direct === "object") {
+		return { mediaType: "application/json", entry: direct as Record<string, unknown> };
+	}
+	for (const key of Object.keys(content)) {
+		if (/json/i.test(key)) {
+			const entry = content[key];
+			if (entry && typeof entry === "object") {
+				return { mediaType: key, entry: entry as Record<string, unknown> };
+			}
+		}
+	}
+	const wildcard = content["*/*"];
+	if (wildcard && typeof wildcard === "object") {
+		return { mediaType: "*/*", entry: wildcard as Record<string, unknown> };
+	}
+	return null;
+}
+
+// ---------------------------------------------------------------------------
 // Schema resolution
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Two generator fixes bundled for the 2.0.0-alpha.21 test build.

**`*/*` and json-variant media types** — `pickJsonContent` helper now picks success-response content with priority `application/json` → any `/json/i` variant → `*/*` fallback, applied at all four parse sites, both `resolveOperationSchema` branches, and the validator's response/body quality checks. Operations whose Swagger spec only declares `*/*` for 2xx (e.g. `getDashboardChecklist`, `deleteOrganisation`, `validateOrganisationSlug`) now emit `Promise<Result<\${Base}Response>>` instead of `Result<unknown>`.

**Property-key quoting** — `formatPropertyKey` wraps non-identifier names like `hub.mode` (Instagram webhook verification) in `JSON.stringify`, applied in `schemaToTS` inline objects and Schema Models interfaces, fixing TS1131/TS1109 syntax errors in generated `api.contracts.ts`.

Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded JSON media-type detection to support schema variants, vendor types, and fallback options in OpenAPI specifications

* **Improvements**
  * Enhanced TypeScript property name formatting to properly handle special characters and non-standard identifiers

* **Chores**
  * Version bump to 2.0.0-alpha.21

<!-- end of auto-generated comment: release notes by coderabbit.ai -->