### PR TITLE
test: add vitest snapshot suite for generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "@types/node": "^22.0.0",
         "@types/react": "^19.2.14",
         "typescript": "^5.9.0",
-        "vite": "^6.0.0"
+        "vite": "^6.0.0",
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1232,6 +1233,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@opentui/core": {
       "version": "0.1.90",
       "resolved": "https://registry.npmjs.org/@opentui/core/-/core-0.1.90.tgz",
@@ -1703,10 +1711,35 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -1735,6 +1768,119 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@webgpu/types": {
@@ -1776,6 +1922,16 @@
       "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
       "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/await-to-js": {
       "version": "3.0.0",
@@ -1913,6 +2069,16 @@
         "win32"
       ]
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chardet": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
@@ -1946,6 +2112,13 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1966,6 +2139,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -2010,6 +2190,16 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -2032,6 +2222,16 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
       "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2197,6 +2397,16 @@
       "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/marked": {
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
@@ -2249,6 +2459,17 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/omggif": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
@@ -2282,6 +2503,13 @@
         "xml-parse-from-string": "^1.0.0",
         "xml2js": "^0.5.0"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/peek-readable": {
       "version": "4.1.0",
@@ -2583,6 +2811,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -2613,6 +2848,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -2682,11 +2931,28 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -2703,6 +2969,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/token-types": {
@@ -2764,6 +3040,7 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -2833,6 +3110,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/web-tree-sitter": {
       "version": "0.25.10",
       "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.10.tgz",
@@ -2846,6 +3213,23 @@
         "@types/emscripten": {
           "optional": true
         }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "dev": "tsc --watch",
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
     "prepublishOnly": "npm run build",
-    "test": "echo \"No tests configured\""
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@inquirer/prompts": "^7.0.0",
@@ -42,7 +43,8 @@
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.14",
     "typescript": "^5.9.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.1.5"
   },
   "peerDependencies": {
     "vite": ">=5.0.0"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "url": "git+ssh://git@github.com/oddFEELING/chowbea-axios.git"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "license": "MIT",
   "author": "Emmanuel Alawode"

--- a/tests/fixtures/edge-cases.json
+++ b/tests/fixtures/edge-cases.json
@@ -1,0 +1,175 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Edge Cases",
+    "version": "1.0.0",
+    "description": "Spec exercising known generator edge cases (issues #13–#19, #22, #26, #31, #32)."
+  },
+  "paths": {
+    "/users/{id}": {
+      "get": {
+        "operationId": "get-user",
+        "summary": "Get user by id (kebab-case operationId — issue #13)",
+        "description": "Multi-line description containing */ comment-break attempt (issue #14).",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/User" }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "get_user",
+        "summary": "Update user (snake_case collides with get-user via sanitizeIdentifier — issue #18)",
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      },
+      "head": {
+        "operationId": "head-user",
+        "summary": "HEAD method (currently dropped — issue #31)",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/items": {
+      "get": {
+        "operationId": "list-items",
+        "summary": "Wildcard media type (*/*) — relies on pickJsonContent fallback",
+        "responses": {
+          "200": {
+            "description": "List",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Item" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create-item",
+        "summary": "Enum with quote/backslash — issue #15",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "enum": ["a\"b", "c\\d", "normal"]
+                  },
+                  "hub.mode": { "type": "string" }
+                },
+                "required": ["name"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created. Description with */ in it.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Item" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/upload": {
+      "post": {
+        "operationId": "upload-file",
+        "summary": "Multipart heuristic misclassifies profile/filename — issue #22",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": { "type": "string", "format": "binary" },
+                  "profile": { "type": "string" },
+                  "filename": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/dictionary": {
+      "get": {
+        "operationId": "get-dictionary",
+        "summary": "additionalProperties currently dropped — issue #32",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" }
+                  },
+                  "additionalProperties": { "type": "string" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "description": "A user. Description containing */ injection attempt — issue #14.",
+        "required": ["id", "name"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "email": { "type": "string", "format": "email" },
+          "friends": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/User" }
+          }
+        }
+      },
+      "Item": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "tags": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/petstore.json
+++ b/tests/fixtures/petstore.json
@@ -1,0 +1,120 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Petstore",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/pets": {
+      "get": {
+        "operationId": "listPets",
+        "summary": "List pets",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "format": "int32" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of pets",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Pet" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createPet",
+        "summary": "Create a pet",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/NewPet" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Pet" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "operationId": "getPetById",
+        "summary": "Get a pet by id",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Pet" }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "Deleted" }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "tag": { "type": "string" },
+          "status": { "type": "string", "enum": ["available", "pending", "sold"] }
+        }
+      },
+      "NewPet": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string" },
+          "tag": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/tests/generator.test.snap
+++ b/tests/generator.test.snap
@@ -1,0 +1,1456 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`generator: client files (api.helpers.ts, api.instance.ts, api.error.ts, api.client.ts) > default instance config snapshot > api.client.ts 1`] = `
+"/**
+ * Typed HTTP client for API.
+ * 
+ * This file is generated once by chowbea-axios CLI.
+ * You can safely modify this file - it will NOT be overwritten.
+ */
+
+import type { AxiosRequestConfig, AxiosResponse } from "axios";
+
+import { axiosInstance } from "./api.instance";
+import { safeRequest, type Result } from "./api.error";
+import type { paths, components, operations } from "./_generated/api.types";
+import { createOperations } from "./_generated/api.operations";
+
+/* ~ =================================== ~ */
+/* -- Type Helpers -- */
+/* ~ =================================== ~ */
+
+/** All path templates defined by the OpenAPI paths map. */
+type Paths = keyof paths;
+
+/** HTTP methods supported by the client. */
+type HttpMethod = "get" | "post" | "put" | "delete" | "patch";
+
+/** Resolves the OpenAPI operation schema for a given path and method. */
+type Operation<P extends Paths, M extends HttpMethod> = paths[P][M];
+
+/** Extracts placeholder parameter names from an OpenAPI-style path template. */
+type ExtractPathParamNames<T extends string> =
+	T extends \`\${string}{\${infer P}}\${infer R}\`
+		? P | ExtractPathParamNames<R>
+		: never;
+
+/** Maps extracted path parameter names to a simple serializable value type. */
+type PathParams<P extends Paths> = ExtractPathParamNames<
+	P & string
+> extends never
+	? never
+	: Record<ExtractPathParamNames<P & string>, string | number | boolean>;
+
+/** Extracts query parameter types from the OpenAPI operation schema. */
+type QueryParams<P extends Paths, M extends HttpMethod> = Operation<
+	P,
+	M
+> extends { parameters: { query?: infer Q } }
+	? Q extends Record<string, unknown>
+		? Q
+		: never
+	: never;
+
+/** Extended Axios config that includes typed query parameters. */
+type TypedAxiosConfig<P extends Paths, M extends HttpMethod> = Omit<
+	AxiosRequestConfig,
+	"params"
+> & {
+	params?: QueryParams<P, M>;
+};
+
+/** Maps OpenAPI form-data field types to their runtime equivalents. */
+type MapFormDataTypes<T> = T extends Record<string, unknown>
+	? {
+			[K in keyof T]: K extends
+				| \`\${string}image\${string}\`
+				| \`\${string}file\${string}\`
+				| \`\${string}attachment\${string}\`
+				| \`\${string}upload\${string}\`
+				| \`\${string}document\${string}\`
+				| \`\${string}photo\${string}\`
+				| \`\${string}video\${string}\`
+				| \`\${string}media\${string}\`
+				? T[K] extends string[]
+					? File[]
+					: T[K] extends string
+						? File | Blob
+						: T[K]
+				: T[K];
+		}
+	: T;
+
+/** Infers the request body type for a given path/method pair. */
+type RequestBody<P extends Paths, M extends HttpMethod> = Operation<
+	P,
+	M
+> extends {
+	requestBody: { content: { "application/json": infer T } };
+}
+	? T extends Record<string, never>
+		? Record<string, unknown>
+		: T
+	: Operation<P, M> extends {
+				requestBody?: { content: { "application/json": infer T } };
+			}
+		? T extends Record<string, never>
+			? Record<string, unknown>
+			: T
+		: Operation<P, M> extends {
+					requestBody: { content: { "multipart/form-data": infer T } };
+				}
+			? MapFormDataTypes<T>
+			: Operation<P, M> extends {
+						requestBody?: { content: { "multipart/form-data": infer T } };
+					}
+				? MapFormDataTypes<T>
+				: never;
+
+/** Infers the JSON response body type for a given status code. */
+type ResponseData<
+	P extends Paths,
+	M extends HttpMethod,
+> = Operation<P, M> extends {
+	responses: { 200: { content: { "application/json": infer T } } };
+}
+	? T
+	: Operation<P, M> extends {
+				responses: { 201: { content: { "application/json": infer T } } };
+			}
+		? T
+		: unknown;
+
+/* ~ =================================== ~ */
+/* -- Utility Functions -- */
+/* ~ =================================== ~ */
+
+/**
+ * Replaces {param} placeholders in a path template using provided values.
+ */
+function interpolatePath<P extends Paths>(
+	template: P,
+	params?: PathParams<P> | never
+): string {
+	const pathStr = String(template);
+	if (!params) return pathStr;
+
+	const missing: string[] = [];
+	const result = pathStr.replace(/\\{([^}]+)\\}/g, (match, key: string) => {
+		const value = (params as Record<string, unknown>)[key];
+		if (value === undefined || value === null) {
+			missing.push(key);
+			return match;
+		}
+		return encodeURIComponent(String(value));
+	});
+
+	if (missing.length > 0) {
+		throw new Error(
+			\`Missing required path param(s): \${missing.join(", ")} for template: \${pathStr}\`
+		);
+	}
+
+	return result;
+}
+
+/**
+ * Checks if the request should use multipart/form-data.
+ */
+function shouldUseFormData(path: string, data: unknown): boolean {
+	if (data instanceof FormData) return true;
+	const formDataPatterns = [/\\/upload-images$/, /\\/upload$/, /\\/files\\/upload$/];
+	return formDataPatterns.some((pattern) => pattern.test(path));
+}
+
+/**
+ * Converts a plain object to FormData for multipart/form-data requests.
+ */
+function convertToFormData(data: Record<string, unknown>): FormData {
+	const formData = new FormData();
+	for (const [key, value] of Object.entries(data)) {
+		if (value === undefined || value === null) continue;
+		if (value instanceof File || value instanceof Blob) {
+			formData.append(key, value);
+		} else if (Array.isArray(value)) {
+			for (const item of value) {
+				if (item instanceof File || item instanceof Blob) {
+					formData.append(key, item);
+				} else {
+					formData.append(key, String(item));
+				}
+			}
+		} else {
+			formData.append(key, String(value));
+		}
+	}
+	return formData;
+}
+
+/* ~ =================================== ~ */
+/* -- API Client -- */
+/* ~ =================================== ~ */
+
+/**
+ * Typed API client with Result-based error handling.
+ * All methods return { data, error } instead of throwing.
+ */
+const api = {
+	/**
+	 * Sends a GET request to the given OpenAPI path.
+	 * Returns Result<T> - never throws.
+	 */
+	get<P extends Paths>(
+		url: P,
+		...args: PathParams<P> extends never
+			? [config?: TypedAxiosConfig<P, "get">]
+			: [pathParams: PathParams<P>, config?: TypedAxiosConfig<P, "get">]
+	): Promise<Result<ResponseData<P, "get">>> {
+		const hasPathParams = String(url).includes("{");
+		const [pathParamsOrConfig, config] = args;
+
+		const pathParams = hasPathParams
+			? (pathParamsOrConfig as PathParams<P>)
+			: undefined;
+		const finalConfig = hasPathParams
+			? (config as TypedAxiosConfig<P, "get"> | undefined)
+			: (pathParamsOrConfig as TypedAxiosConfig<P, "get"> | undefined);
+
+		return safeRequest(
+			axiosInstance.get<ResponseData<P, "get">>(
+				interpolatePath(url, pathParams),
+				finalConfig
+			)
+		);
+	},
+
+	/**
+	 * Sends a POST request with a body inferred from the OpenAPI spec.
+	 * Returns Result<T> - never throws.
+	 */
+	post<P extends Paths>(
+		url: P,
+		data: RequestBody<P, "post">,
+		...args: PathParams<P> extends never
+			? [config?: TypedAxiosConfig<P, "post">]
+			: [pathParams: PathParams<P>, config?: TypedAxiosConfig<P, "post">]
+	): Promise<Result<ResponseData<P, "post">>> {
+		const hasPathParams = String(url).includes("{");
+		const [pathParamsOrConfig, config] = args;
+
+		const pathParams = hasPathParams
+			? (pathParamsOrConfig as PathParams<P>)
+			: undefined;
+		const finalConfig = hasPathParams
+			? (config as TypedAxiosConfig<P, "post"> | undefined)
+			: (pathParamsOrConfig as TypedAxiosConfig<P, "post"> | undefined);
+
+		const resolvedPath = interpolatePath(url, pathParams);
+		const requestData = shouldUseFormData(resolvedPath, data)
+			? data instanceof FormData
+				? data
+				: convertToFormData(data as Record<string, unknown>)
+			: data;
+
+		return safeRequest(
+			axiosInstance.post<ResponseData<P, "post">>(
+				resolvedPath,
+				requestData,
+				finalConfig
+			)
+		);
+	},
+
+	/**
+	 * Sends a PUT request with a JSON body.
+	 * Returns Result<T> - never throws.
+	 */
+	put<P extends Paths>(
+		url: P,
+		data: RequestBody<P, "put">,
+		...args: PathParams<P> extends never
+			? [config?: TypedAxiosConfig<P, "put">]
+			: [pathParams: PathParams<P>, config?: TypedAxiosConfig<P, "put">]
+	): Promise<Result<ResponseData<P, "put">>> {
+		const hasPathParams = String(url).includes("{");
+		const [pathParamsOrConfig, config] = args;
+
+		const pathParams = hasPathParams
+			? (pathParamsOrConfig as PathParams<P>)
+			: undefined;
+		const finalConfig = hasPathParams
+			? (config as TypedAxiosConfig<P, "put"> | undefined)
+			: (pathParamsOrConfig as TypedAxiosConfig<P, "put"> | undefined);
+
+		return safeRequest(
+			axiosInstance.put<ResponseData<P, "put">>(
+				interpolatePath(url, pathParams),
+				data,
+				finalConfig
+			)
+		);
+	},
+
+	/**
+	 * Sends a DELETE request.
+	 * Returns Result<T> - never throws.
+	 */
+	delete<P extends Paths>(
+		url: P,
+		...args: PathParams<P> extends never
+			? [config?: TypedAxiosConfig<P, "delete">]
+			: [pathParams: PathParams<P>, config?: TypedAxiosConfig<P, "delete">]
+	): Promise<Result<ResponseData<P, "delete">>> {
+		const hasPathParams = String(url).includes("{");
+		const [pathParamsOrConfig, config] = args;
+
+		const pathParams = hasPathParams
+			? (pathParamsOrConfig as PathParams<P>)
+			: undefined;
+		const finalConfig = hasPathParams
+			? (config as TypedAxiosConfig<P, "delete"> | undefined)
+			: (pathParamsOrConfig as TypedAxiosConfig<P, "delete"> | undefined);
+
+		return safeRequest(
+			axiosInstance.delete<ResponseData<P, "delete">>(
+				interpolatePath(url, pathParams),
+				finalConfig
+			)
+		);
+	},
+
+	/**
+	 * Sends a PATCH request with a JSON body.
+	 * Returns Result<T> - never throws.
+	 */
+	patch<P extends Paths>(
+		url: P,
+		data: RequestBody<P, "patch">,
+		...args: PathParams<P> extends never
+			? [config?: TypedAxiosConfig<P, "patch">]
+			: [pathParams: PathParams<P>, config?: TypedAxiosConfig<P, "patch">]
+	): Promise<Result<ResponseData<P, "patch">>> {
+		const hasPathParams = String(url).includes("{");
+		const [pathParamsOrConfig, config] = args;
+
+		const pathParams = hasPathParams
+			? (pathParamsOrConfig as PathParams<P>)
+			: undefined;
+		const finalConfig = hasPathParams
+			? (config as TypedAxiosConfig<P, "patch"> | undefined)
+			: (pathParamsOrConfig as TypedAxiosConfig<P, "patch"> | undefined);
+
+		return safeRequest(
+			axiosInstance.patch<ResponseData<P, "patch">>(
+				interpolatePath(url, pathParams),
+				data,
+				finalConfig
+			)
+		);
+	},
+
+	/**
+	 * Operation-based API methods generated from OpenAPI operationIds.
+	 * Provides semantic function names instead of raw path endpoints.
+	 */
+	get op() {
+		return createOperations(this);
+	},
+};
+
+export { api };
+export type { Paths, HttpMethod, PathParams, QueryParams, RequestBody, ResponseData };
+
+// Re-export error types for convenience
+export type { ApiError, Result, RequestContext } from "./api.error";
+export { createApiError, safeRequest, isSuccess, isError } from "./api.error";
+
+// Re-export types for convenience
+export type { paths, components, operations };
+"
+`;
+
+exports[`generator: client files (api.helpers.ts, api.instance.ts, api.error.ts, api.client.ts) > default instance config snapshot > api.error.ts 1`] = `
+"/**
+ * Result-based error handling for API calls.
+ * 
+ * This file is generated once by chowbea-axios CLI.
+ * You can safely modify this file - it will NOT be overwritten.
+ */
+
+import { AxiosError, type AxiosResponse } from "axios";
+
+/* ~ =================================== ~ */
+/* -- Types -- */
+/* ~ =================================== ~ */
+
+/**
+ * Request context for debugging - what request caused the error.
+ */
+export interface RequestContext {
+	/** HTTP method (GET, POST, etc.) */
+	method: string;
+	/** URL that was called */
+	url: string;
+	/** Base URL from axios config */
+	baseURL?: string;
+	/** Query parameters */
+	params?: unknown;
+	/** Request body (sensitive fields redacted) */
+	data?: unknown;
+}
+
+/**
+ * Normalized API error with extracted message and metadata.
+ */
+export interface ApiError {
+	/** Human-readable error message */
+	message: string;
+	/** Error code (NETWORK_ERROR, VALIDATION_ERROR, etc.) */
+	code: string;
+	/** HTTP status code (null for network errors) */
+	status: number | null;
+	/** What request caused this error */
+	request: RequestContext;
+	/** Original error response body for debugging */
+	details?: unknown;
+}
+
+/**
+ * Result type - API calls return this instead of throwing.
+ * Success: { data: T, error: null }
+ * Failure: { data: null, error: ApiError }
+ */
+export type Result<T> =
+	| { data: T; error: null }
+	| { data: null; error: ApiError };
+
+/* ~ =================================== ~ */
+/* -- Error Normalization -- */
+/* ~ =================================== ~ */
+
+/**
+ * Normalizes error messages from various API response formats.
+ * Handles common patterns from different backend frameworks.
+ */
+export function normalizeErrorMessage(error: unknown): string {
+	if (!error || typeof error !== "object") {
+		return "An unexpected error occurred";
+	}
+
+	const e = error as Record<string, unknown>;
+
+	// Common: { message: "..." }
+	if (typeof e.message === "string") return e.message;
+
+	// .NET: { error: "..." } or { error: { message: "..." } }
+	if (e.error) {
+		if (typeof e.error === "string") return e.error;
+		if (typeof (e.error as Record<string, unknown>)?.message === "string") {
+			return (e.error as Record<string, unknown>).message as string;
+		}
+	}
+
+	// Validation: { errors: [...] } or { errors: { field: [...] } }
+	if (e.errors) {
+		if (Array.isArray(e.errors)) {
+			const first = e.errors[0];
+			if (typeof first === "string") return first;
+			if (typeof first?.message === "string") return first.message;
+		} else if (typeof e.errors === "object") {
+			const firstField = Object.values(e.errors)[0];
+			if (Array.isArray(firstField) && firstField.length > 0) {
+				return String(firstField[0]);
+			}
+		}
+	}
+
+	// FastAPI: { detail: "..." } or { detail: [...] }
+	if (typeof e.detail === "string") return e.detail;
+	if (Array.isArray(e.detail) && e.detail[0]?.msg) {
+		return e.detail[0].msg;
+	}
+
+	// ASP.NET Problem Details: { title: "..." }
+	if (typeof e.title === "string") return e.title;
+
+	return "An unexpected error occurred";
+}
+
+/* ~ =================================== ~ */
+/* -- Request Context Extraction -- */
+/* ~ =================================== ~ */
+
+/** Fields that should be redacted from request data */
+const SENSITIVE_FIELDS = [
+	"password",
+	"token",
+	"secret",
+	"authorization",
+	"apikey",
+	"api_key",
+	"access_token",
+	"refresh_token",
+];
+
+/**
+ * Redacts sensitive fields from request data for safe logging.
+ */
+function redactSensitive(data: unknown): unknown {
+	if (!data || typeof data !== "object") return data;
+
+	const redacted = { ...(data as Record<string, unknown>) };
+
+	for (const key of Object.keys(redacted)) {
+		if (SENSITIVE_FIELDS.some((s) => key.toLowerCase().includes(s))) {
+			redacted[key] = "[REDACTED]";
+		}
+	}
+
+	return redacted;
+}
+
+/**
+ * Extracts request context from AxiosError for debugging.
+ */
+function extractRequestContext(err: AxiosError): RequestContext {
+	const config = err.config;
+
+	return {
+		method: config?.method?.toUpperCase() || "UNKNOWN",
+		url: config?.url || "unknown",
+		baseURL: config?.baseURL,
+		params: config?.params,
+		data: redactSensitive(config?.data),
+	};
+}
+
+/* ~ =================================== ~ */
+/* -- Error Creation -- */
+/* ~ =================================== ~ */
+
+/**
+ * Maps HTTP status codes to error codes.
+ */
+function getErrorCode(status: number): string {
+	if (status >= 500) return "SERVER_ERROR";
+	switch (status) {
+		case 400:
+			return "BAD_REQUEST";
+		case 401:
+			return "UNAUTHORIZED";
+		case 403:
+			return "FORBIDDEN";
+		case 404:
+			return "NOT_FOUND";
+		case 409:
+			return "CONFLICT";
+		case 422:
+			return "VALIDATION_ERROR";
+		case 429:
+			return "RATE_LIMITED";
+		default:
+			return "REQUEST_ERROR";
+	}
+}
+
+/**
+ * Creates an ApiError from any error.
+ */
+export function createApiError(err: unknown): ApiError {
+	if (err instanceof AxiosError) {
+		const request = extractRequestContext(err);
+
+		// Network error (no response)
+		if (!err.response) {
+			return {
+				message: err.code === "ECONNABORTED" 
+					? "Request timed out" 
+					: "Network error - please check your connection",
+				code: err.code === "ECONNABORTED" ? "TIMEOUT" : "NETWORK_ERROR",
+				status: null,
+				request,
+				details: { code: err.code, message: err.message },
+			};
+		}
+
+		// Server responded with error
+		const status = err.response.status;
+
+		return {
+			message: normalizeErrorMessage(err.response.data),
+			code: getErrorCode(status),
+			status,
+			request,
+			details: err.response.data,
+		};
+	}
+
+	// Unknown error
+	return {
+		message: err instanceof Error ? err.message : "An unexpected error occurred",
+		code: "UNKNOWN_ERROR",
+		status: null,
+		request: { method: "UNKNOWN", url: "unknown" },
+		details: err,
+	};
+}
+
+/* ~ =================================== ~ */
+/* -- Safe Request Wrapper -- */
+/* ~ =================================== ~ */
+
+/**
+ * Wraps an axios promise and returns a Result instead of throwing.
+ * 
+ * @example
+ * \`\`\`typescript
+ * const { data, error } = await safeRequest(axios.get("/users"));
+ * if (error) {
+ *   console.error(error.message);
+ *   return;
+ * }
+ * console.log(data);
+ * \`\`\`
+ */
+export async function safeRequest<T>(
+	promise: Promise<AxiosResponse<T>>
+): Promise<Result<T>> {
+	try {
+		const response = await promise;
+		return { data: response.data, error: null };
+	} catch (err) {
+		return { data: null, error: createApiError(err) };
+	}
+}
+
+/**
+ * Type guard to check if a result is successful.
+ */
+export function isSuccess<T>(result: Result<T>): result is { data: T; error: null } {
+	return result.error === null;
+}
+
+/**
+ * Type guard to check if a result is an error.
+ */
+export function isError<T>(result: Result<T>): result is { data: null; error: ApiError } {
+	return result.error !== null;
+}
+"
+`;
+
+exports[`generator: client files (api.helpers.ts, api.instance.ts, api.error.ts, api.client.ts) > default instance config snapshot > api.helpers.ts 1`] = `
+"/**
+ * Type utilities for extracting request/response types from OpenAPI schema.
+ * 
+ * This file is generated once by chowbea-axios CLI.
+ * You can safely modify this file - it will NOT be overwritten.
+ */
+
+import type { paths, components, operations } from "./_generated/api.types";
+
+/* ~ =================================== ~ */
+/* -- Base Types -- */
+/* ~ =================================== ~ */
+
+/** All path templates defined by the OpenAPI paths map. */
+type Paths = keyof paths;
+
+/** HTTP methods supported by the client. */
+type HttpMethod = "get" | "post" | "put" | "delete" | "patch";
+
+/** Resolves the OpenAPI operation schema for a given path and method. */
+type Operation<P extends Paths, M extends HttpMethod> = paths[P][M];
+
+/* ~ =================================== ~ */
+/* -- Path Parameter Extraction -- */
+/* ~ =================================== ~ */
+
+/** Extracts placeholder parameter names from an OpenAPI-style path template. */
+type ExtractPathParamNames<T extends string> =
+	T extends \`\${string}{\${infer P}}\${infer R}\`
+		? P | ExtractPathParamNames<R>
+		: never;
+
+/** Maps extracted path parameter names to a simple serializable value type. */
+type PathParams<P extends Paths> = ExtractPathParamNames<P & string> extends never
+	? never
+	: Record<ExtractPathParamNames<P & string>, string | number | boolean>;
+
+/* ~ =================================== ~ */
+/* -- Query Parameter Extraction -- */
+/* ~ =================================== ~ */
+
+/** Extracts query parameter types from the OpenAPI operation schema. */
+type QueryParams<P extends Paths, M extends HttpMethod> = Operation<P, M> extends {
+	parameters: { query?: infer Q };
+}
+	? Q extends Record<string, unknown>
+		? Q
+		: never
+	: never;
+
+/* ~ =================================== ~ */
+/* -- Request Body Extraction -- */
+/* ~ =================================== ~ */
+
+/** Maps OpenAPI form-data field types to their runtime equivalents. */
+type MapFormDataTypes<T> = T extends Record<string, unknown>
+	? {
+			[K in keyof T]: K extends
+				| \`\${string}image\${string}\`
+				| \`\${string}file\${string}\`
+				| \`\${string}attachment\${string}\`
+				| \`\${string}upload\${string}\`
+				| \`\${string}document\${string}\`
+				| \`\${string}photo\${string}\`
+				| \`\${string}video\${string}\`
+				| \`\${string}media\${string}\`
+				? T[K] extends string[]
+					? File[]
+					: T[K] extends string
+						? File | Blob
+						: T[K]
+				: T[K];
+		}
+	: T;
+
+/** Infers the request body type for a given path/method pair from OpenAPI. */
+type RequestBody<P extends Paths, M extends HttpMethod> = Operation<P, M> extends {
+	requestBody: { content: { "application/json": infer T } };
+}
+	? T extends Record<string, never>
+		? Record<string, unknown>
+		: T
+	: Operation<P, M> extends { requestBody?: { content: { "application/json": infer T } } }
+		? T extends Record<string, never>
+			? Record<string, unknown>
+			: T
+		: Operation<P, M> extends { requestBody: { content: { "multipart/form-data": infer T } } }
+			? MapFormDataTypes<T>
+			: Operation<P, M> extends { requestBody?: { content: { "multipart/form-data": infer T } } }
+				? MapFormDataTypes<T>
+				: never;
+
+/* ~ =================================== ~ */
+/* -- Response Data Extraction -- */
+/* ~ =================================== ~ */
+
+/** Extracts all available status codes from an operation's responses. */
+type AvailableStatusCodes<P extends Paths, M extends HttpMethod> = Operation<P, M> extends {
+	responses: infer R;
+}
+	? R extends Record<string, unknown>
+		? keyof R & number
+		: never
+	: never;
+
+/** Infers the JSON response body type for a given status code from OpenAPI. */
+type ResponseData<
+	P extends Paths,
+	M extends HttpMethod,
+	Status extends AvailableStatusCodes<P, M> = 200 extends AvailableStatusCodes<P, M>
+		? 200
+		: AvailableStatusCodes<P, M>,
+> = Operation<P, M> extends {
+	responses: { [K in Status]: { content: { "application/json": infer T } } };
+}
+	? T
+	: never;
+
+/* ~ =================================== ~ */
+/* -- Intellisense Helpers -- */
+/* ~ =================================== ~ */
+
+/**
+ * Forces TypeScript to expand and display the full type structure.
+ * Improves intellisense by showing actual type properties instead of type references.
+ */
+type Expand<T> = T extends (...args: infer A) => infer R
+	? (...args: Expand<A>) => Expand<R>
+	: T extends object
+		? T extends infer O
+			? { [K in keyof O]: O[K] }
+			: never
+		: T;
+
+/**
+ * Recursively expands nested types for better intellisense.
+ * Expands all levels of nested objects to show full type structure.
+ */
+type ExpandRecursively<T> = T extends (...args: infer A) => infer R
+	? (...args: ExpandRecursively<A>) => ExpandRecursively<R>
+	: T extends object
+		? T extends infer O
+			? { [K in keyof O]: ExpandRecursively<O[K]> }
+			: never
+		: T;
+
+/* ~ =================================== ~ */
+/* -- Path-Based API Type Helpers -- */
+/* ~ =================================== ~ */
+
+/**
+ * Extract request body type for a given path and method.
+ * @example type CreateUserInput = ApiRequestBody<"/api/users", "post">
+ */
+export type ApiRequestBody<P extends Paths, M extends HttpMethod> = ExpandRecursively<
+	RequestBody<P, M>
+>;
+
+/**
+ * Extract response data type for a given path, method, and status code.
+ * @example type UserResponse = ApiResponseData<"/api/users/{id}", "get">
+ * @example type CreatedResponse = ApiResponseData<"/api/users", "post", 201>
+ */
+export type ApiResponseData<
+	P extends Paths,
+	M extends HttpMethod,
+	Status extends AvailableStatusCodes<P, M> = 200 extends AvailableStatusCodes<P, M>
+		? 200
+		: AvailableStatusCodes<P, M>,
+> = ExpandRecursively<ResponseData<P, M, Status>>;
+
+/**
+ * Extract path parameters for a given path.
+ * @example type UserPathParams = ApiPathParams<"/api/users/{id}">
+ */
+export type ApiPathParams<P extends Paths> = ExpandRecursively<PathParams<P>>;
+
+/**
+ * Extract query parameters for a given path and method.
+ * @example type ListUsersQuery = ApiQueryParams<"/api/users", "get">
+ */
+export type ApiQueryParams<P extends Paths, M extends HttpMethod> = ExpandRecursively<
+	QueryParams<P, M>
+>;
+
+/**
+ * Get all available status codes for a given path and method.
+ * @example type UserStatusCodes = ApiStatusCodes<"/api/users/{id}", "get">
+ */
+export type ApiStatusCodes<P extends Paths, M extends HttpMethod> = AvailableStatusCodes<P, M>;
+
+/* ~ =================================== ~ */
+/* -- Operation-Based API Type Helpers -- */
+/* ~ =================================== ~ */
+
+/** Extracts all available status codes from an operation's responses by operation ID. */
+type OperationStatusCodes<OpId extends keyof operations> = operations[OpId] extends {
+	responses: infer R;
+}
+	? R extends Record<string, unknown>
+		? keyof R & number
+		: never
+	: never;
+
+/** Determines the default positive status code for an operation. */
+type OperationPositiveStatus<OpId extends keyof operations> =
+	200 extends OperationStatusCodes<OpId>
+		? 200
+		: 201 extends OperationStatusCodes<OpId>
+			? 201
+			: 202 extends OperationStatusCodes<OpId>
+				? 202
+				: 204 extends OperationStatusCodes<OpId>
+					? 204
+					: OperationStatusCodes<OpId>;
+
+/**
+ * Extract request body type by operation ID.
+ * @example type CreateUserInput = ServerRequestBody<"createUser">
+ * @see Use concrete types in _generated/api.contracts.ts for cmd+click navigation
+ */
+export type ServerRequestBody<OpId extends keyof operations> = ExpandRecursively<
+	operations[OpId] extends { requestBody: { content: { "application/json": infer T } } }
+		? T extends Record<string, never>
+			? Record<string, unknown>
+			: T
+		: operations[OpId] extends { requestBody?: { content: { "application/json": infer T } } }
+			? T extends Record<string, never>
+				? Record<string, unknown>
+				: T
+			: never
+>;
+
+/**
+ * Extract request parameters (path and query) by operation ID.
+ * @example type GetUserParams = ServerRequestParams<"getUserById">
+ * @see Use concrete types in _generated/api.contracts.ts for cmd+click navigation
+ */
+export type ServerRequestParams<OpId extends keyof operations> = ExpandRecursively<
+	operations[OpId] extends { parameters: infer P }
+		? P extends { path?: infer Path; query?: infer Query }
+			? (Path extends Record<string, unknown> ? { path: Path } : {}) &
+					(Query extends Record<string, unknown> ? { query?: Query } : {})
+			: P extends { path?: infer Path }
+				? Path extends Record<string, unknown>
+					? { path: Path }
+					: {}
+				: P extends { query?: infer Query }
+					? Query extends Record<string, unknown>
+						? { query?: Query }
+						: {}
+					: {}
+		: {}
+>;
+
+/**
+ * Extract response type by operation ID with optional status code.
+ * Defaults to the positive status code (200, 201, 202, or 204).
+ * @example type UserResponse = ServerResponseType<"getUserById">
+ * @example type NotFoundResponse = ServerResponseType<"getUserById", 404>
+ * @see Use concrete types in _generated/api.contracts.ts for cmd+click navigation
+ */
+export type ServerResponseType<
+	OpId extends keyof operations,
+	Status extends OperationStatusCodes<OpId> = OperationPositiveStatus<OpId>,
+> = ExpandRecursively<
+	operations[OpId] extends {
+		responses: { [K in Status]: { content: { "application/json": infer T } } };
+	}
+		? T
+		: never
+>;
+
+/**
+ * Extract model/schema type from OpenAPI components.
+ * @example type User = ServerModel<"UserContract">
+ * @example type Meeting = ServerModel<"MeetingContract">
+ * @see Use concrete types in _generated/api.contracts.ts for cmd+click navigation
+ */
+export type ServerModel<ModelName extends keyof components["schemas"]> = ExpandRecursively<
+	components["schemas"][ModelName]
+>;
+
+/* ~ =================================== ~ */
+/* -- Re-exports for Convenience -- */
+/* ~ =================================== ~ */
+
+export type { Paths, HttpMethod, Expand, ExpandRecursively };
+"
+`;
+
+exports[`generator: client files (api.helpers.ts, api.instance.ts, api.error.ts, api.client.ts) > default instance config snapshot > api.instance.ts 1`] = `
+"/**
+ * Axios instance with authentication interceptor.
+ *
+ * This file is generated once by chowbea-axios CLI.
+ * You can safely modify this file - it will NOT be overwritten.
+ */
+
+import axios from "axios";
+
+/**
+ * Shared Axios instance configured with the API base URL.
+ */
+export const axiosInstance = axios.create({
+	baseURL: process.env.API_BASE_URL,
+	withCredentials: true,
+	timeout: 30000,
+});
+
+/**
+ * Request interceptor for authentication.
+ * TODO: Implement your auth logic here.
+ *
+ * Examples:
+ *   config.headers.Authorization = \`Bearer \${getToken()}\`;
+ *   config.headers["X-API-Key"] = getApiKey();
+ */
+axiosInstance.interceptors.request.use(
+	(config) => {
+		// Add your auth logic here
+		return config;
+	},
+	(error) => Promise.reject(error)
+);
+"
+`;
+
+exports[`generator: end-to-end snapshots > edge-cases — kebab/snake collision, JSDoc/enum injection, recursion, additionalProperties, HEAD method, multipart heuristic > api.contracts.ts 1`] = `
+"/**
+ * Concrete type contracts extracted from OpenAPI spec.
+ *
+ * Auto-generated by chowbea-axios CLI.
+ * DO NOT EDIT MANUALLY - changes will be overwritten.
+ *
+ * Every type is fully expanded inline — no indirection, no generic references.
+ * Cmd+click any type to see its full structure right here.
+ */
+
+/* ~ =================================== ~ */
+/* -- Schema Models -- */
+/* ~ =================================== ~ */
+
+/**
+  * A user. Description containing */ injection attempt — issue #14.
+ * Schema: User
+ */
+export interface User {
+	id: string;
+	name: string;
+	email?: string;
+	friends?: {
+		id: string;
+		name: string;
+		email?: string;
+		friends?: unknown[];
+	}[];
+}
+
+/**
+ * Schema: Item
+ */
+export interface Item {
+	id?: number;
+	tags?: string[];
+}
+
+/* ~ =================================== ~ */
+/* -- Operation Responses -- */
+/* ~ =================================== ~ */
+
+/** Response: GET /users/{id} (200 - OK) */
+export type Get_userResponse200 = {
+	id: string;
+	name: string;
+	email?: string;
+	friends?: unknown[];
+};
+
+/** Response: GET /users/{id} (happy path) */
+export type Get_userResponse = Get_userResponse200;
+
+/** Response: GET /items (200 - List) */
+export type List_itemsResponse200 = {
+	id?: number;
+	tags?: string[];
+}[];
+
+/** Response: GET /items (happy path) */
+export type List_itemsResponse = List_itemsResponse200;
+
+/** Response: POST /items (201 - Created. Description with */ in it.) */
+export type Create_itemResponse201 = {
+	id?: number;
+	tags?: string[];
+};
+
+/** Response: POST /items (happy path) */
+export type Create_itemResponse = Create_itemResponse201;
+
+/** Response: GET /dictionary (200 - OK) */
+export type Get_dictionaryResponse200 = {
+	id?: string;
+};
+
+/** Response: GET /dictionary (happy path) */
+export type Get_dictionaryResponse = Get_dictionaryResponse200;
+
+/* ~ =================================== ~ */
+/* -- Operation Request Bodies -- */
+/* ~ =================================== ~ */
+
+/** Request body: POST /items */
+export type Create_itemBody = {
+	name: "a"b" | "c\\d" | "normal";
+	"hub.mode"?: string;
+};
+
+/** Request body: POST /upload */
+export type Upload_fileBody = {
+	file?: File | Blob;
+	profile?: string;
+	filename?: string;
+};
+
+/* ~ =================================== ~ */
+/* -- Operation Path Parameters -- */
+/* ~ =================================== ~ */
+
+/** Path params: GET /users/{id} */
+export type Get_userPathParams = {
+	id: string;
+};
+"
+`;
+
+exports[`generator: end-to-end snapshots > edge-cases — kebab/snake collision, JSDoc/enum injection, recursion, additionalProperties, HEAD method, multipart heuristic > api.operations.ts 1`] = `
+"/**
+ * Auto-generated API operations from OpenAPI spec.
+ *
+ * This file is automatically generated by chowbea-axios CLI.
+ * DO NOT EDIT MANUALLY - your changes will be overwritten.
+ *
+ * Total operations: 6
+ */
+
+/* ~ =================================== ~ */
+/* -- This file provides semantic operation-based API functions -- */
+/* -- Use apiClient.op.operationName() instead of raw paths -- */
+/* ~ =================================== ~ */
+
+import type { AxiosRequestConfig } from "axios"
+import type { Result } from "../api.error"
+import type {
+  Create_itemBody,
+  Create_itemResponse,
+  Get_dictionaryResponse,
+  Get_userPathParams,
+  Get_userResponse,
+  List_itemsResponse,
+  Upload_fileBody,
+} from "./api.contracts"
+
+/* ~ =================================== ~ */
+/* -- Type Helpers -- */
+/* ~ =================================== ~ */
+
+/**
+ * Maps OpenAPI form-data field types to their runtime equivalents.
+ * Uses field names to intelligently detect file upload fields vs regular string fields.
+ *
+ * File field patterns: images, files, attachments, uploads, documents, photos, videos, media
+ * Regular string fields: All other string/string[] fields remain unchanged
+ */
+type MapFormDataTypes<T> = T extends Record<string, unknown>
+  ? {
+      [K in keyof T]:
+        // Check if field name suggests it's a file upload field
+        K extends \`\${string}image\${string}\` | \`\${string}file\${string}\` | \`\${string}attachment\${string}\` |
+                   \`\${string}upload\${string}\` | \`\${string}document\${string}\` | \`\${string}photo\${string}\` |
+                   \`\${string}video\${string}\` | \`\${string}media\${string}\`
+          ? T[K] extends string[]
+            ? File[]  // File upload fields become File[]
+            : T[K] extends string
+              ? File | Blob  // Single file becomes File or Blob
+              : T[K]
+          : T[K];  // Non-file fields keep their original type
+    }
+  : T;
+
+/**
+ * Axios request config with typed query parameters for operations that accept them.
+ * The type parameter Q is the operation-specific QueryParams contract from api.contracts.
+ */
+type RequestConfig<Q> = Omit<AxiosRequestConfig, "params"> & {
+  params?: Q
+}
+
+/* ~ =================================== ~ */
+/* -- Generated Operations -- */
+/* ~ =================================== ~ */
+
+/**
+ * Collection of all API operations extracted from the OpenAPI spec.
+ * Each operation is a typed function that wraps the underlying apiClient methods.
+ * 
+ * @example
+ * \`\`\`typescript
+ * // Using operation-based API
+ * await apiClient.op.getUserById({ id: "123" })
+ * 
+ * // With query parameters
+ * await apiClient.op.listUsers({ params: { limit: 10, offset: 0 } })
+ * 
+ * // With request body
+ * await apiClient.op.createUser({ name: "John", email: "john@example.com" })
+ * \`\`\`
+ */
+export const createOperations = (apiClient: any) => ({
+  /**
+   * Get user by id (kebab-case operationId — issue #13)
+   * Multi-line description containing */ comment-break attempt (issue #14).
+   * 
+   * @operationId get-user
+   * @method GET
+   * @path /users/{id}
+   */
+  get-user: (pathParams: Get_userPathParams, config?: AxiosRequestConfig): Promise<Result<Get_userResponse>> => apiClient.get("/users/{id}", pathParams, config),
+
+  /**
+   * Update user (snake_case collides with get-user via sanitizeIdentifier — issue #18)
+   * 
+   * @operationId get_user
+   * @method PATCH
+   * @path /users/{id}
+   */
+  get_user: (pathParams: Get_userPathParams, config?: AxiosRequestConfig): Promise<Result<unknown>> => apiClient.patch("/users/{id}", undefined, pathParams, config),
+
+  /**
+   * Wildcard media type (*/*) — relies on pickJsonContent fallback
+   * 
+   * @operationId list-items
+   * @method GET
+   * @path /items
+   */
+  list-items: (config?: AxiosRequestConfig): Promise<Result<List_itemsResponse>> => apiClient.get("/items", config),
+
+  /**
+   * Enum with quote/backslash — issue #15
+   * 
+   * @operationId create-item
+   * @method POST
+   * @path /items
+   */
+  create-item: (data: Create_itemBody, config?: AxiosRequestConfig): Promise<Result<Create_itemResponse>> => apiClient.post("/items", data, config),
+
+  /**
+   * Multipart heuristic misclassifies profile/filename — issue #22
+   * 
+   * @operationId upload-file
+   * @method POST
+   * @path /upload
+   */
+  upload-file: (data: MapFormDataTypes<Upload_fileBody>, config?: AxiosRequestConfig): Promise<Result<unknown>> => apiClient.post("/upload", data, config),
+
+  /**
+   * additionalProperties currently dropped — issue #32
+   * 
+   * @operationId get-dictionary
+   * @method GET
+   * @path /dictionary
+   */
+  get-dictionary: (config?: AxiosRequestConfig): Promise<Result<Get_dictionaryResponse>> => apiClient.get("/dictionary", config),
+}) as const
+
+/**
+ * Type representing all available API operations.
+ * This type is inferred from the createOperations return value for proper TypeScript support.
+ */
+export type ApiOperations = ReturnType<typeof createOperations>
+"
+`;
+
+exports[`generator: end-to-end snapshots > petstore — clean canonical spec > api.contracts.ts 1`] = `
+"/**
+ * Concrete type contracts extracted from OpenAPI spec.
+ *
+ * Auto-generated by chowbea-axios CLI.
+ * DO NOT EDIT MANUALLY - changes will be overwritten.
+ *
+ * Every type is fully expanded inline — no indirection, no generic references.
+ * Cmd+click any type to see its full structure right here.
+ */
+
+/* ~ =================================== ~ */
+/* -- Schema Models -- */
+/* ~ =================================== ~ */
+
+/**
+ * Schema: Pet
+ */
+export interface Pet {
+	id: string;
+	name: string;
+	tag?: string;
+	status?: "available" | "pending" | "sold";
+}
+
+/**
+ * Schema: NewPet
+ */
+export interface NewPet {
+	name: string;
+	tag?: string;
+}
+
+/* ~ =================================== ~ */
+/* -- Operation Responses -- */
+/* ~ =================================== ~ */
+
+/** Response: GET /pets (200 - A list of pets) */
+export type ListPetsResponse200 = ({
+	id: string;
+	name: string;
+	tag?: string;
+	status?: "available" | "pending" | "sold";
+})[];
+
+/** Response: GET /pets (happy path) */
+export type ListPetsResponse = ListPetsResponse200;
+
+/** Response: POST /pets (201 - Created) */
+export type CreatePetResponse201 = {
+	id: string;
+	name: string;
+	tag?: string;
+	status?: "available" | "pending" | "sold";
+};
+
+/** Response: POST /pets (happy path) */
+export type CreatePetResponse = CreatePetResponse201;
+
+/** Response: GET /pets/{petId} (200 - OK) */
+export type GetPetByIdResponse200 = {
+	id: string;
+	name: string;
+	tag?: string;
+	status?: "available" | "pending" | "sold";
+};
+
+/** Response: GET /pets/{petId} (happy path) */
+export type GetPetByIdResponse = GetPetByIdResponse200;
+
+/* ~ =================================== ~ */
+/* -- Operation Request Bodies -- */
+/* ~ =================================== ~ */
+
+/** Request body: POST /pets */
+export type CreatePetBody = {
+	name: string;
+	tag?: string;
+};
+
+/* ~ =================================== ~ */
+/* -- Operation Path Parameters -- */
+/* ~ =================================== ~ */
+
+/** Path params: GET /pets/{petId} */
+export type GetPetByIdPathParams = {
+	petId: string;
+};
+
+/** Path params: DELETE /pets/{petId} */
+export type DeletePetPathParams = {
+	petId: string;
+};
+
+/* ~ =================================== ~ */
+/* -- Operation Query Parameters -- */
+/* ~ =================================== ~ */
+
+/** Query params: GET /pets */
+export type ListPetsQueryParams = {
+	limit?: number;
+};
+"
+`;
+
+exports[`generator: end-to-end snapshots > petstore — clean canonical spec > api.operations.ts 1`] = `
+"/**
+ * Auto-generated API operations from OpenAPI spec.
+ *
+ * This file is automatically generated by chowbea-axios CLI.
+ * DO NOT EDIT MANUALLY - your changes will be overwritten.
+ *
+ * Total operations: 4
+ */
+
+/* ~ =================================== ~ */
+/* -- This file provides semantic operation-based API functions -- */
+/* -- Use apiClient.op.operationName() instead of raw paths -- */
+/* ~ =================================== ~ */
+
+import type { AxiosRequestConfig } from "axios"
+import type { Result } from "../api.error"
+import type {
+  CreatePetBody,
+  CreatePetResponse,
+  DeletePetPathParams,
+  GetPetByIdPathParams,
+  GetPetByIdResponse,
+  ListPetsQueryParams,
+  ListPetsResponse,
+} from "./api.contracts"
+
+/* ~ =================================== ~ */
+/* -- Type Helpers -- */
+/* ~ =================================== ~ */
+
+/**
+ * Maps OpenAPI form-data field types to their runtime equivalents.
+ * Uses field names to intelligently detect file upload fields vs regular string fields.
+ *
+ * File field patterns: images, files, attachments, uploads, documents, photos, videos, media
+ * Regular string fields: All other string/string[] fields remain unchanged
+ */
+type MapFormDataTypes<T> = T extends Record<string, unknown>
+  ? {
+      [K in keyof T]:
+        // Check if field name suggests it's a file upload field
+        K extends \`\${string}image\${string}\` | \`\${string}file\${string}\` | \`\${string}attachment\${string}\` |
+                   \`\${string}upload\${string}\` | \`\${string}document\${string}\` | \`\${string}photo\${string}\` |
+                   \`\${string}video\${string}\` | \`\${string}media\${string}\`
+          ? T[K] extends string[]
+            ? File[]  // File upload fields become File[]
+            : T[K] extends string
+              ? File | Blob  // Single file becomes File or Blob
+              : T[K]
+          : T[K];  // Non-file fields keep their original type
+    }
+  : T;
+
+/**
+ * Axios request config with typed query parameters for operations that accept them.
+ * The type parameter Q is the operation-specific QueryParams contract from api.contracts.
+ */
+type RequestConfig<Q> = Omit<AxiosRequestConfig, "params"> & {
+  params?: Q
+}
+
+/* ~ =================================== ~ */
+/* -- Generated Operations -- */
+/* ~ =================================== ~ */
+
+/**
+ * Collection of all API operations extracted from the OpenAPI spec.
+ * Each operation is a typed function that wraps the underlying apiClient methods.
+ * 
+ * @example
+ * \`\`\`typescript
+ * // Using operation-based API
+ * await apiClient.op.getUserById({ id: "123" })
+ * 
+ * // With query parameters
+ * await apiClient.op.listUsers({ params: { limit: 10, offset: 0 } })
+ * 
+ * // With request body
+ * await apiClient.op.createUser({ name: "John", email: "john@example.com" })
+ * \`\`\`
+ */
+export const createOperations = (apiClient: any) => ({
+  /**
+   * List pets
+   * 
+   * @operationId listPets
+   * @method GET
+   * @path /pets
+   */
+  listPets: (config?: RequestConfig<ListPetsQueryParams>): Promise<Result<ListPetsResponse>> => apiClient.get("/pets", config),
+
+  /**
+   * Create a pet
+   * 
+   * @operationId createPet
+   * @method POST
+   * @path /pets
+   */
+  createPet: (data: CreatePetBody, config?: AxiosRequestConfig): Promise<Result<CreatePetResponse>> => apiClient.post("/pets", data, config),
+
+  /**
+   * Get a pet by id
+   * 
+   * @operationId getPetById
+   * @method GET
+   * @path /pets/{petId}
+   */
+  getPetById: (pathParams: GetPetByIdPathParams, config?: AxiosRequestConfig): Promise<Result<GetPetByIdResponse>> => apiClient.get("/pets/{petId}", pathParams, config),
+
+  /**
+   * 
+   * @operationId deletePet
+   * @method DELETE
+   * @path /pets/{petId}
+   */
+  deletePet: (pathParams: DeletePetPathParams, config?: AxiosRequestConfig): Promise<Result<unknown>> => apiClient.delete("/pets/{petId}", pathParams, config),
+}) as const
+
+/**
+ * Type representing all available API operations.
+ * This type is inferred from the createOperations return value for proper TypeScript support.
+ */
+export type ApiOperations = ReturnType<typeof createOperations>
+"
+`;

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -1,0 +1,184 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+import { runClientFiles, runGenerator } from "./helpers/run-generator.js";
+
+const FIXTURE_DIR = new URL("./fixtures/", import.meta.url);
+
+async function loadFixture(name: string): Promise<object> {
+	const url = new URL(name, FIXTURE_DIR);
+	return JSON.parse(await readFile(url, "utf8"));
+}
+
+describe("generator: end-to-end snapshots", () => {
+	it("petstore — clean canonical spec", async () => {
+		const spec = await loadFixture("petstore.json");
+		const { operations, contracts, cleanup } = await runGenerator(spec);
+		try {
+			expect(operations).toMatchSnapshot("api.operations.ts");
+			expect(contracts).toMatchSnapshot("api.contracts.ts");
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("edge-cases — kebab/snake collision, JSDoc/enum injection, recursion, additionalProperties, HEAD method, multipart heuristic", async () => {
+		const spec = await loadFixture("edge-cases.json");
+		const { operations, contracts, cleanup } = await runGenerator(spec);
+		try {
+			expect(operations).toMatchSnapshot("api.operations.ts");
+			expect(contracts).toMatchSnapshot("api.contracts.ts");
+		} finally {
+			await cleanup();
+		}
+	});
+});
+
+describe("generator: client files (api.helpers.ts, api.instance.ts, api.error.ts, api.client.ts)", () => {
+	it("default instance config snapshot", async () => {
+		const { helpers, instance, error, client, cleanup } =
+			await runClientFiles();
+		try {
+			expect(helpers).toMatchSnapshot("api.helpers.ts");
+			expect(instance).toMatchSnapshot("api.instance.ts");
+			expect(error).toMatchSnapshot("api.error.ts");
+			expect(client).toMatchSnapshot("api.client.ts");
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("auth_mode=bearer-localstorage emits a tokenKey constant", async () => {
+		const { instance, cleanup } = await runClientFiles({
+			auth_mode: "bearer-localstorage",
+			token_key: "my-token-key",
+		});
+		try {
+			expect(instance).toMatch(/export const tokenKey = "my-token-key";/);
+			expect(instance).toMatch(/localStorage\.getItem\(tokenKey\)/);
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("auth_mode=none emits no auth interceptor", async () => {
+		const { instance, cleanup } = await runClientFiles({
+			auth_mode: "none",
+		});
+		try {
+			expect(instance).not.toMatch(/interceptors\.request\.use/);
+			expect(instance).not.toMatch(/Authorization/);
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("with_credentials propagates literally to axios.create", async () => {
+		const { instance, cleanup } = await runClientFiles({
+			with_credentials: false,
+		});
+		try {
+			expect(instance).toMatch(/withCredentials: false,/);
+		} finally {
+			await cleanup();
+		}
+	});
+});
+
+describe("generator: known-bug regression markers", () => {
+	// These tests document bugs reported in the package review (#13–#22).
+	// They are written in a form that will FAIL once the bugs are fixed,
+	// at which point each `.fails` should flip to a positive assertion in
+	// the same PR that ships the fix. This keeps the test file as a record
+	// of which bugs are still latent vs resolved.
+
+	it.fails("#13: operation keys with `-` should be quoted in api.operations.ts", async () => {
+		const spec = await loadFixture("edge-cases.json");
+		const { operations, cleanup } = await runGenerator(spec);
+		try {
+			// Today the generator emits `get-user: (...) => …` (unquoted).
+			// After fix: `"get-user": (...) => …`.
+			expect(operations).not.toMatch(/^\s+get-user:/m);
+			expect(operations).toMatch(/^\s+"get-user":/m);
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it.fails("#14: descriptions containing `*/` must not break JSDoc comments", async () => {
+		const spec = await loadFixture("edge-cases.json");
+		const { contracts, operations, cleanup } = await runGenerator(spec);
+		try {
+			// After fix, raw `*/` should not appear inside the body of any
+			// JSDoc block. Today the contracts file leaks `*/ injection in
+			// description` into code position.
+			const body = contracts + "\n" + operations;
+			// Look for `*/` followed by anything but whitespace+end-of-comment-block
+			const lines = body.split("\n");
+			for (const line of lines) {
+				// Allow legitimate comment terminators (a line that's just */ optionally indented)
+				if (/^\s*\*\/\s*$/.test(line)) continue;
+				expect(line).not.toMatch(/\*\//);
+			}
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it.fails("#15: enum string values containing `\"` or `\\` must be properly escaped", async () => {
+		const spec = await loadFixture("edge-cases.json");
+		const { contracts, cleanup } = await runGenerator(spec);
+		try {
+			// Today emits `name: "a"b" | "c\d" | "normal"` (broken).
+			// After fix, JSON.stringify-escaped: `name: "a\"b" | "c\\d" | "normal"`.
+			expect(contracts).toMatch(/"a\\"b"/);
+			expect(contracts).toMatch(/"c\\\\d"/);
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it.fails("#18: distinct operationIds that sanitize to the same identifier must be detected", async () => {
+		// The fixture has both `get-user` (GET) and `get_user` (PATCH) — both
+		// sanitize to `get_user`. After fix, this should throw or warn at
+		// generation time. Today it silently collapses contracts.
+		const spec = await loadFixture("edge-cases.json");
+		await expect(runGenerator(spec)).rejects.toThrow(/collision|duplicate/i);
+	});
+
+	it.fails("#26: recursive types should reference themselves, not collapse to unknown[]", async () => {
+		const spec = await loadFixture("edge-cases.json");
+		const { contracts, cleanup } = await runGenerator(spec);
+		try {
+			// Today emits `friends?: unknown[]`.
+			// After fix: `friends?: User[]` (or some self-referential alias).
+			expect(contracts).not.toMatch(/friends\?:\s*unknown\[\]/);
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it.fails("#31: HEAD method operations should appear in api.operations.ts", async () => {
+		const spec = await loadFixture("edge-cases.json");
+		const { operations, cleanup } = await runGenerator(spec);
+		try {
+			// `head-user` operation should be emitted alongside get/patch.
+			expect(operations).toMatch(/head-user/);
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it.fails("#32: additionalProperties should not be silently dropped", async () => {
+		const spec = await loadFixture("edge-cases.json");
+		const { contracts, cleanup } = await runGenerator(spec);
+		try {
+			// `/dictionary` GET response has additionalProperties: { type: string }.
+			// After fix: emitted type should include `Record<string, string>` or
+			// an index signature `[key: string]: string`.
+			expect(contracts).toMatch(/Record<string,\s*string>|\[key:\s*string\]:\s*string/);
+		} finally {
+			await cleanup();
+		}
+	});
+});

--- a/tests/helpers/run-generator.ts
+++ b/tests/helpers/run-generator.ts
@@ -63,6 +63,10 @@ export async function makeTempPaths(): Promise<{
  * Run the generator end-to-end against an in-memory spec.
  * Skips `openapi-typescript` (the dlx step) so tests don't depend on
  * spawning a child process or being online.
+ *
+ * On any failure (writeFile / generate / readFile), the temp tree is
+ * removed before the error propagates so tests don't leak temp dirs
+ * across failure cases.
  */
 export async function runGenerator(spec: object): Promise<{
 	operations: string;
@@ -70,18 +74,24 @@ export async function runGenerator(spec: object): Promise<{
 	cleanup: () => Promise<void>;
 }> {
 	const { paths, cleanup } = await makeTempPaths();
-	await writeFile(paths.spec, JSON.stringify(spec, null, 2), "utf8");
-
-	await generate({ paths, logger: SILENT_LOGGER, skipTypes: true });
-
-	const operations = await readFile(paths.operations, "utf8");
-	const contracts = await readFile(paths.contracts, "utf8");
-	return { operations, contracts, cleanup };
+	try {
+		await writeFile(paths.spec, JSON.stringify(spec, null, 2), "utf8");
+		await generate({ paths, logger: SILENT_LOGGER, skipTypes: true });
+		const operations = await readFile(paths.operations, "utf8");
+		const contracts = await readFile(paths.contracts, "utf8");
+		return { operations, contracts, cleanup };
+	} catch (err) {
+		await cleanup();
+		throw err;
+	}
 }
 
 /**
  * Run `generateClientFiles` against the given instance config.
  * Returns the contents of each emitted file.
+ *
+ * On any failure, the temp tree is cleaned up before the error
+ * propagates.
  */
 export async function runClientFiles(
 	overrides: Partial<InstanceConfig> = {},
@@ -93,14 +103,19 @@ export async function runClientFiles(
 	cleanup: () => Promise<void>;
 }> {
 	const { paths, cleanup } = await makeTempPaths();
-	await generateClientFiles({
-		paths,
-		instanceConfig: { ...DEFAULT_INSTANCE_CONFIG, ...overrides },
-		logger: SILENT_LOGGER,
-	});
-	const helpers = await readFile(paths.helpers, "utf8");
-	const instance = await readFile(paths.instance, "utf8");
-	const error = await readFile(paths.error, "utf8");
-	const client = await readFile(paths.client, "utf8");
-	return { helpers, instance, error, client, cleanup };
+	try {
+		await generateClientFiles({
+			paths,
+			instanceConfig: { ...DEFAULT_INSTANCE_CONFIG, ...overrides },
+			logger: SILENT_LOGGER,
+		});
+		const helpers = await readFile(paths.helpers, "utf8");
+		const instance = await readFile(paths.instance, "utf8");
+		const error = await readFile(paths.error, "utf8");
+		const client = await readFile(paths.client, "utf8");
+		return { helpers, instance, error, client, cleanup };
+	} catch (err) {
+		await cleanup();
+		throw err;
+	}
 }

--- a/tests/helpers/run-generator.ts
+++ b/tests/helpers/run-generator.ts
@@ -1,0 +1,106 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { GeneratorPaths } from "../../src/core/generator.js";
+import { generate, generateClientFiles } from "../../src/core/generator.js";
+import type { InstanceConfig } from "../../src/core/config.js";
+import { DEFAULT_INSTANCE_CONFIG } from "../../src/core/config.js";
+import type { Logger } from "../../src/adapters/logger-interface.js";
+
+const SILENT_LOGGER: Logger = {
+	level: "silent",
+	header: () => {},
+	step: () => {},
+	info: (() => {}) as Logger["info"],
+	warn: (() => {}) as Logger["warn"],
+	error: (() => {}) as Logger["error"],
+	debug: (() => {}) as Logger["debug"],
+	done: () => {},
+	startProgress: () => {},
+	stopProgress: () => {},
+};
+
+/**
+ * Build a temp output tree and matching `GeneratorPaths`.
+ * Caller is responsible for `cleanup()`-ing it.
+ */
+export async function makeTempPaths(): Promise<{
+	paths: GeneratorPaths;
+	cleanup: () => Promise<void>;
+}> {
+	const root = join(
+		tmpdir(),
+		`chowbea-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	const internalDir = join(root, "_internal");
+	const generatedDir = join(root, "_generated");
+	await mkdir(internalDir, { recursive: true });
+	await mkdir(generatedDir, { recursive: true });
+
+	const paths: GeneratorPaths = {
+		folder: root,
+		internal: internalDir,
+		generated: generatedDir,
+		spec: join(internalDir, "openapi.json"),
+		cache: join(internalDir, ".api-cache.json"),
+		types: join(generatedDir, "api.types.ts"),
+		operations: join(generatedDir, "api.operations.ts"),
+		contracts: join(generatedDir, "api.contracts.ts"),
+		helpers: join(root, "api.helpers.ts"),
+		instance: join(root, "api.instance.ts"),
+		error: join(root, "api.error.ts"),
+		client: join(root, "api.client.ts"),
+	};
+
+	return {
+		paths,
+		cleanup: () => rm(root, { recursive: true, force: true }),
+	};
+}
+
+/**
+ * Run the generator end-to-end against an in-memory spec.
+ * Skips `openapi-typescript` (the dlx step) so tests don't depend on
+ * spawning a child process or being online.
+ */
+export async function runGenerator(spec: object): Promise<{
+	operations: string;
+	contracts: string;
+	cleanup: () => Promise<void>;
+}> {
+	const { paths, cleanup } = await makeTempPaths();
+	await writeFile(paths.spec, JSON.stringify(spec, null, 2), "utf8");
+
+	await generate({ paths, logger: SILENT_LOGGER, skipTypes: true });
+
+	const operations = await readFile(paths.operations, "utf8");
+	const contracts = await readFile(paths.contracts, "utf8");
+	return { operations, contracts, cleanup };
+}
+
+/**
+ * Run `generateClientFiles` against the given instance config.
+ * Returns the contents of each emitted file.
+ */
+export async function runClientFiles(
+	overrides: Partial<InstanceConfig> = {},
+): Promise<{
+	helpers: string;
+	instance: string;
+	error: string;
+	client: string;
+	cleanup: () => Promise<void>;
+}> {
+	const { paths, cleanup } = await makeTempPaths();
+	await generateClientFiles({
+		paths,
+		instanceConfig: { ...DEFAULT_INSTANCE_CONFIG, ...overrides },
+		logger: SILENT_LOGGER,
+	});
+	const helpers = await readFile(paths.helpers, "utf8");
+	const instance = await readFile(paths.instance, "utf8");
+	const error = await readFile(paths.error, "utf8");
+	const client = await readFile(paths.client, "utf8");
+	return { helpers, instance, error, client, cleanup };
+}

--- a/tests/ref-utils.test.ts
+++ b/tests/ref-utils.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	pickJsonContent,
+	refName,
+	resolveObject,
+	resolveRef,
+	resolveSchema,
+} from "../src/core/ref-utils.js";
+
+describe("resolveRef", () => {
+	const spec = {
+		components: {
+			schemas: {
+				User: { type: "object", properties: { id: { type: "string" } } },
+			},
+		},
+	};
+
+	it("resolves a simple ref", () => {
+		expect(resolveRef("#/components/schemas/User", spec)).toEqual(
+			spec.components.schemas.User,
+		);
+	});
+
+	it("returns undefined for unresolvable path", () => {
+		expect(resolveRef("#/components/schemas/Missing", spec)).toBeUndefined();
+	});
+
+	it("returns undefined for non-fragment refs", () => {
+		expect(resolveRef("https://example.com/spec.json", spec)).toBeUndefined();
+		expect(resolveRef("./other.json", spec)).toBeUndefined();
+	});
+
+	it("returns undefined for non-string input", () => {
+		expect(resolveRef(123 as unknown as string, spec)).toBeUndefined();
+	});
+
+	// Issue #19: JSON Pointer escape sequences ~0 (~) and ~1 (/) are not decoded.
+	it.fails("#19: decodes ~1 to '/' per RFC 6901", () => {
+		const refs = {
+			paths: {
+				"/users/{id}": { get: { operationId: "x" } },
+			},
+		};
+		// `#/paths/~1users~1{id}/get` should resolve to the GET operation.
+		expect(resolveRef("#/paths/~1users~1{id}/get", refs)).toEqual({
+			operationId: "x",
+		});
+	});
+
+	it.fails("#19: decodes ~0 to '~' per RFC 6901", () => {
+		const refs = { components: { schemas: { "weird~name": { type: "string" } } } };
+		expect(resolveRef("#/components/schemas/weird~0name", refs)).toEqual({
+			type: "string",
+		});
+	});
+});
+
+describe("refName", () => {
+	it("returns the last segment", () => {
+		expect(refName("#/components/schemas/User")).toBe("User");
+	});
+
+	it("falls back to the full ref for unparseable inputs", () => {
+		expect(refName("not-a-ref")).toBe("not-a-ref");
+	});
+});
+
+describe("resolveObject", () => {
+	const spec = {
+		components: {
+			parameters: {
+				IdParam: { name: "id", in: "path", required: true },
+			},
+		},
+	};
+
+	it("follows a $ref", () => {
+		const obj = { $ref: "#/components/parameters/IdParam" };
+		expect(resolveObject(obj, spec)).toEqual({
+			name: "id",
+			in: "path",
+			required: true,
+		});
+	});
+
+	it("returns the object as-is when there is no $ref", () => {
+		const obj = { name: "limit", in: "query" };
+		expect(resolveObject(obj, spec)).toEqual(obj);
+	});
+
+	it("returns the object as-is when the $ref does not resolve", () => {
+		const obj = { $ref: "#/components/parameters/Missing" };
+		expect(resolveObject(obj, spec)).toEqual(obj);
+	});
+});
+
+describe("pickJsonContent", () => {
+	it("prefers exact application/json", () => {
+		const content = {
+			"application/json": { schema: { type: "string" } },
+			"application/xml": { schema: { type: "object" } },
+		};
+		expect(pickJsonContent(content)).toEqual({
+			mediaType: "application/json",
+			entry: { schema: { type: "string" } },
+		});
+	});
+
+	it("falls back to any json-flavored media type", () => {
+		const content = {
+			"application/vnd.api+json": { schema: { type: "object" } },
+			"text/html": { schema: {} },
+		};
+		expect(pickJsonContent(content)?.mediaType).toBe(
+			"application/vnd.api+json",
+		);
+	});
+
+	it("falls back to */* as a last resort (Swagger-generated specs)", () => {
+		const content = { "*/*": { schema: { type: "string" } } };
+		expect(pickJsonContent(content)?.mediaType).toBe("*/*");
+	});
+
+	it("returns null when no json-compatible content exists", () => {
+		const content = {
+			"text/plain": { schema: {} },
+			"image/png": { schema: {} },
+		};
+		expect(pickJsonContent(content)).toBeNull();
+	});
+
+	it("returns null for undefined input", () => {
+		expect(pickJsonContent(undefined)).toBeNull();
+	});
+});
+
+describe("resolveSchema", () => {
+	const spec = {};
+
+	it("returns null for null/undefined schemas", () => {
+		expect(resolveSchema(null, spec, 0, 8, new Set())).toBeNull();
+		expect(resolveSchema(undefined, spec, 0, 8, new Set())).toBeNull();
+	});
+
+	it("respects max depth", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				nested: {
+					type: "object",
+					properties: { x: { type: "string" } },
+				},
+			},
+		};
+		const result = resolveSchema(schema, spec, 0, 1, new Set());
+		// At depth 1, the top is fine, but nested should be truncated.
+		expect(result?.properties?.nested?.truncated).toBe(true);
+	});
+
+	it("captures OpenAPI 3.1 array-style nullable", () => {
+		const schema = { type: ["string", "null"] };
+		const result = resolveSchema(schema, spec, 0, 8, new Set());
+		expect(result?.type).toBe("string");
+		expect(result?.nullable).toBe(true);
+	});
+
+	it("captures OpenAPI 3.0 nullable shorthand", () => {
+		const schema = { type: "string", nullable: true };
+		const result = resolveSchema(schema, spec, 0, 8, new Set());
+		expect(result?.nullable).toBe(true);
+	});
+
+	it("preserves enum values", () => {
+		const schema = { type: "string", enum: ["a", "b", "c"] };
+		const result = resolveSchema(schema, spec, 0, 8, new Set());
+		expect(result?.enum).toEqual(["a", "b", "c"]);
+	});
+
+	it("breaks circular $ref via the visited set", () => {
+		const cyclic: Record<string, unknown> = {
+			components: { schemas: {} },
+		};
+		(cyclic.components as { schemas: Record<string, unknown> }).schemas.User = {
+			type: "object",
+			properties: {
+				friend: { $ref: "#/components/schemas/User" },
+			},
+		};
+		const result = resolveSchema(
+			{ $ref: "#/components/schemas/User" },
+			cyclic,
+			0,
+			8,
+			new Set(),
+		);
+		// Top-level is User; friend's recursive ref should be truncated.
+		expect(result?.properties?.friend?.truncated).toBe(true);
+	});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["tests/**/*.test.ts"],
+		environment: "node",
+		// Snapshot files live next to the test that produced them.
+		resolveSnapshotPath: (testPath, snapExtension) =>
+			testPath.replace(/\.test\.ts$/, `.test${snapExtension}`),
+	},
+});


### PR DESCRIPTION
## Summary
- Establishes regression safety net before the upcoming critical fixes
- Adds vitest + 2 fixtures (petstore + edge-cases) + 2 test files (generator + ref-utils)
- Captures today's broken output as snapshots; PR2 will update them when fixing #13/#15/#18

Refs #21 (test foundation per the review tracking issue #47).

## What's covered
- **End-to-end snapshots** of `api.operations.ts` and `api.contracts.ts` for both fixtures (skips `openapi-typescript` dlx via `generate({ skipTypes: true })`)
- **Snapshots of client files** (`api.helpers.ts`, `api.instance.ts`, `api.error.ts`, `api.client.ts`) under default config
- **Variant assertions** for `auth_mode`: `bearer-localstorage` (emits `tokenKey` constant), `none` (no interceptor), and `with_credentials: false` propagation
- **Unit tests for ref-utils**: `resolveRef`, `refName`, `resolveObject`, `pickJsonContent`, `resolveSchema` (incl. depth guard, OpenAPI 3.1 array-style nullable, OpenAPI 3.0 nullable, circular `$ref` truncation)
- **Known-bug regression markers** using `it.fails()` for issues #13, #14, #15, #18, #19, #26, #31, #32. Each marker is written so it flips to a positive assertion when the bug is fixed in the corresponding PR.

## Test results on this branch
```
Test Files  2 passed (2)
     Tests  26 passed | 9 expected fail (35)
```

The 9 expected-fails correspond exactly to the known-bug markers — they document which bugs are still latent and will turn green as fixes land.

## Out of scope
- Adding tests for `config.ts` validators, `fetcher.ts` retry logic, `validate.ts` rules, and individual action handlers — these will follow as their respective fixes go in.
- TUI integration tests (require Bun + a terminal emulator).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
- Added comprehensive test suites for generator and utilities with snapshot validation
- Created test fixtures for API specification edge cases

## Chores
- Established Vitest testing framework with configuration
- Added npm test scripts for test execution and watch mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->