### PR TITLE
security: input sanitization sweep — JSDoc escape, config validation, drop shell:true

### DIFF
--- a/src/core/actions/init.ts
+++ b/src/core/actions/init.ts
@@ -46,6 +46,7 @@ import {
   getDlxCommand,
   getInstallCommand,
   getRunCommand,
+  resolveCommand,
   type PackageManager,
 } from "../pm.js";
 
@@ -274,12 +275,13 @@ async function ensureAxios(
 
   logger.step("deps", "Installing axios...");
 
+  // Drop `shell: true` (deprecated by Node 24 / DEP0190); resolveCommand
+  // handles the Windows `.cmd` shim path. Issue #16.
   const [cmd, ...args] = getInstallCommand(pm, "axios");
-  const result = spawnSync(cmd, args, {
+  const result = spawnSync(resolveCommand(cmd), args, {
     cwd: projectRoot,
     stdio: "pipe",
     timeout: 60_000,
-    shell: true,
   });
 
   if (result.status !== 0) {
@@ -445,12 +447,13 @@ async function ensureConcurrently(
 
   logger.step("deps", "Installing concurrently...");
 
+  // Drop `shell: true` (deprecated by Node 24 / DEP0190); resolveCommand
+  // handles the Windows `.cmd` shim path. Issue #16.
   const [cmd, ...args] = getInstallCommand(pm, "concurrently", true);
-  const result = spawnSync(cmd, args, {
+  const result = spawnSync(resolveCommand(cmd), args, {
     cwd: projectRoot,
     stdio: "pipe",
     timeout: 60_000,
-    shell: true,
   });
 
   if (result.status !== 0) {
@@ -596,11 +599,12 @@ async function runInitialFetch(
 ): Promise<boolean> {
   logger.step("fetch", "Fetching OpenAPI spec and generating types...");
 
+  // Drop `shell: true` (deprecated by Node 24 / DEP0190); resolveCommand
+  // handles the Windows `.cmd` shim path. Issue #16.
   const [cmd, ...dlxArgs] = getDlxCommand(pm);
-  const result = spawnSync(cmd, [...dlxArgs, "chowbea-axios", "fetch"], {
+  const result = spawnSync(resolveCommand(cmd), [...dlxArgs, "chowbea-axios", "fetch"], {
     cwd: projectRoot,
     stdio: "pipe",
-    shell: true,
   });
 
   const runCmd = getRunCommand(pm);

--- a/src/core/generator.ts
+++ b/src/core/generator.ts
@@ -16,7 +16,7 @@ import { findProjectRoot } from "./config.js";
 import type { InstanceConfig, OutputPaths } from "./config.js";
 import { GenerationError } from "./errors.js";
 import type { Logger } from "../adapters/logger-interface.js";
-import { detectPackageManager, getDlxCommand } from "./pm.js";
+import { detectPackageManager, getDlxCommand, resolveCommand } from "./pm.js";
 import { pickJsonContent } from "./ref-utils.js";
 
 /**
@@ -128,19 +128,21 @@ function generateOperationFunction(operation: OperationMetadata): string {
 		: `AxiosRequestConfig`;
 	params.push(`config?: ${configType}`);
 
-	// Generate JSDoc comment
+	// Generate JSDoc comment. Every interpolated user-controlled string is
+	// run through escapeJsdoc so a `*/` in a description/path/operationId
+	// can't close the comment early and leak content into code position.
 	const jsdoc: string[] = [];
 	jsdoc.push("  /**");
 	if (summary) {
-		jsdoc.push(`   * ${summary}`);
+		jsdoc.push(`   * ${escapeJsdoc(summary)}`);
 	}
 	if (description && description !== summary) {
-		jsdoc.push(`   * ${description}`);
+		jsdoc.push(`   * ${escapeJsdoc(description)}`);
 	}
 	jsdoc.push("   * ");
-	jsdoc.push(`   * @operationId ${operationId}`);
+	jsdoc.push(`   * @operationId ${escapeJsdoc(operationId)}`);
 	jsdoc.push(`   * @method ${method.toUpperCase()}`);
-	jsdoc.push(`   * @path ${pathTemplate}`);
+	jsdoc.push(`   * @path ${escapeJsdoc(pathTemplate)}`);
 	jsdoc.push("   */");
 
 	// Generate function with explicit return type - uses Result<T> for consistent error handling.
@@ -149,28 +151,32 @@ function generateOperationFunction(operation: OperationMetadata): string {
 	const responseType = responseStatus !== null ? `${contractBase}Response` : `unknown`;
 	const returnType = `Promise<Result<${responseType}>>`;
 
-	// Build the apiClient call (apiClient methods already return Result<T>)
+	// Build the apiClient call (apiClient methods already return Result<T>).
+	// Use JSON.stringify for the path so any `"` or `\` in the template is
+	// properly escaped as a TS string literal (defense in depth — paths in
+	// real specs rarely contain these, but malformed/malicious specs could).
+	const pathLiteral = JSON.stringify(pathTemplate);
 	let apiCall: string;
 	if (hasRequestBody) {
 		// POST/PUT/PATCH with body
 		if (pathParams.length > 0) {
-			apiCall = `apiClient.${httpMethod}("${pathTemplate}", data, pathParams, config)`;
+			apiCall = `apiClient.${httpMethod}(${pathLiteral}, data, pathParams, config)`;
 		} else {
-			apiCall = `apiClient.${httpMethod}("${pathTemplate}", data, config)`;
+			apiCall = `apiClient.${httpMethod}(${pathLiteral}, data, config)`;
 		}
 	} else {
 		// GET/DELETE without body
 		// PATCH without body still needs undefined as data parameter
 		if (httpMethod === "patch") {
 			if (pathParams.length > 0) {
-				apiCall = `apiClient.${httpMethod}("${pathTemplate}", undefined, pathParams, config)`;
+				apiCall = `apiClient.${httpMethod}(${pathLiteral}, undefined, pathParams, config)`;
 			} else {
-				apiCall = `apiClient.${httpMethod}("${pathTemplate}", undefined, config)`;
+				apiCall = `apiClient.${httpMethod}(${pathLiteral}, undefined, config)`;
 			}
 		} else if (pathParams.length > 0) {
-			apiCall = `apiClient.${httpMethod}("${pathTemplate}", pathParams, config)`;
+			apiCall = `apiClient.${httpMethod}(${pathLiteral}, pathParams, config)`;
 		} else {
-			apiCall = `apiClient.${httpMethod}("${pathTemplate}", config)`;
+			apiCall = `apiClient.${httpMethod}(${pathLiteral}, config)`;
 		}
 	}
 
@@ -575,6 +581,23 @@ function formatPropertyKey(name: string): string {
 }
 
 /**
+ * Escapes the JSDoc comment terminator inside a string so it can't close a
+ * surrounding `/* ... *\/` block. The replacement is unchanged when the
+ * comment is read but the parser no longer matches the literal two-char
+ * sequence.
+ *
+ * Without this, a spec author (or compromised remote spec) including the
+ * terminator inside a description, summary, or path closes the JSDoc
+ * comment early and leaks the rest of the description into the file as raw
+ * TypeScript syntax — at best a parse error, at worst arbitrary code.
+ * Issue #14.
+ */
+function escapeJsdoc(value: string | undefined | null): string {
+	if (value === undefined || value === null) return "";
+	return String(value).replace(/\*\//g, "*\\/");
+}
+
+/**
  * Capitalizes the first letter of a string (for PascalCase conversion from camelCase operationIds).
  */
 function toPascalCase(str: string): string {
@@ -660,7 +683,9 @@ function schemaToTS(
 		const props = Object.entries(properties).map(([key, propSchema]) => {
 			const optional = required.has(key) ? "" : "?";
 			const propType = schemaToTS(propSchema, innerIndent, allSchemas, visited);
-			const desc = propSchema.description ? ` /** ${propSchema.description} */\n${innerIndent}` : "";
+			const desc = propSchema.description
+				? ` /** ${escapeJsdoc(propSchema.description as string)} */\n${innerIndent}`
+				: "";
 			return `${desc}${formatPropertyKey(key)}${optional}: ${propType};`;
 		});
 		return `{\n${innerIndent}${props.join(`\n${innerIndent}`)}\n${indent}}`;
@@ -777,8 +802,10 @@ function generateContractsFileContent(metadata: ContractMetadata): string {
 		for (const [name, schema] of schemaEntries) {
 			const typeName = sanitizeIdentifier(name);
 			const schemaObj = schema as Record<string, unknown>;
-			const desc = schemaObj.description ? ` * ${schemaObj.description}\n ` : "";
-			lines.push(`/**\n ${desc}* Schema: ${name}\n */`);
+			const desc = schemaObj.description
+				? ` * ${escapeJsdoc(schemaObj.description as string)}\n `
+				: "";
+			lines.push(`/**\n ${desc}* Schema: ${escapeJsdoc(name)}\n */`);
 
 			// For object schemas, emit an interface; for others, emit a type alias
 			if (schemaObj.type === "object" || schemaObj.properties) {
@@ -790,7 +817,7 @@ function generateContractsFileContent(metadata: ContractMetadata): string {
 						const optional = required.has(propKey) ? "" : "?";
 						const propType = schemaToTS(propSchema, "\t", allSchemas);
 						if (propSchema.description) {
-							lines.push(`\t/** ${propSchema.description} */`);
+							lines.push(`\t/** ${escapeJsdoc(propSchema.description as string)} */`);
 						}
 						lines.push(`\t${formatPropertyKey(propKey)}${optional}: ${propType};`);
 					}
@@ -822,9 +849,9 @@ function generateContractsFileContent(metadata: ContractMetadata): string {
 			for (const resp of op.allResponses) {
 				if (!resp.hasJsonContent) continue;
 				const statusTypeName = `${baseName}Response${resp.status}`;
-				const desc = resp.description ? ` - ${resp.description}` : "";
+				const desc = resp.description ? ` - ${escapeJsdoc(resp.description)}` : "";
 				const schema = resolveOperationSchema(metadata.spec, op.operationId, "response", resp.status);
-				lines.push(`/** Response: ${op.method.toUpperCase()} ${op.path} (${resp.status}${desc}) */`);
+				lines.push(`/** Response: ${op.method.toUpperCase()} ${escapeJsdoc(op.path)} (${resp.status}${desc}) */`);
 				if (schema) {
 					lines.push(`export type ${statusTypeName} = ${schemaToTS(schema, "", allSchemas)};`);
 				} else {
@@ -837,7 +864,7 @@ function generateContractsFileContent(metadata: ContractMetadata): string {
 			// Emit statusless alias pointing to the primary success response
 			if (op.responseStatus !== null) {
 				const successTypeName = `${baseName}Response${op.responseStatus}`;
-				lines.push(`/** Response: ${op.method.toUpperCase()} ${op.path} (happy path) */`);
+				lines.push(`/** Response: ${op.method.toUpperCase()} ${escapeJsdoc(op.path)} (happy path) */`);
 				lines.push(`export type ${baseName}Response = ${successTypeName};`);
 				lines.push(``);
 			}
@@ -856,7 +883,7 @@ function generateContractsFileContent(metadata: ContractMetadata): string {
 			const typeName = `${toPascalCase(sanitizeIdentifier(op.operationId))}Body`;
 			const contentType = op.hasJsonBody ? "application/json" : "multipart/form-data";
 			const schema = resolveOperationSchema(metadata.spec, op.operationId, "requestBody", undefined, contentType);
-			lines.push(`/** Request body: ${op.method.toUpperCase()} ${op.path} */`);
+			lines.push(`/** Request body: ${op.method.toUpperCase()} ${escapeJsdoc(op.path)} */`);
 			if (schema) {
 				lines.push(`export type ${typeName} = ${schemaToTS(schema, "", allSchemas)};`);
 			} else {
@@ -877,7 +904,7 @@ function generateContractsFileContent(metadata: ContractMetadata): string {
 		for (const op of pathParamOps) {
 			const typeName = `${toPascalCase(sanitizeIdentifier(op.operationId))}PathParams`;
 			const schema = resolveOperationSchema(metadata.spec, op.operationId, "pathParams");
-			lines.push(`/** Path params: ${op.method.toUpperCase()} ${op.path} */`);
+			lines.push(`/** Path params: ${op.method.toUpperCase()} ${escapeJsdoc(op.path)} */`);
 			if (schema) {
 				lines.push(`export type ${typeName} = ${schemaToTS(schema, "", allSchemas)};`);
 			} else {
@@ -898,7 +925,7 @@ function generateContractsFileContent(metadata: ContractMetadata): string {
 		for (const op of queryParamOps) {
 			const typeName = `${toPascalCase(sanitizeIdentifier(op.operationId))}QueryParams`;
 			const schema = resolveOperationSchema(metadata.spec, op.operationId, "queryParams");
-			lines.push(`/** Query params: ${op.method.toUpperCase()} ${op.path} */`);
+			lines.push(`/** Query params: ${op.method.toUpperCase()} ${escapeJsdoc(op.path)} */`);
 			if (schema) {
 				lines.push(`export type ${typeName} = ${schemaToTS(schema, "", allSchemas)};`);
 			} else {
@@ -928,13 +955,16 @@ async function generateTypes(
 
 	logger.debug({ pm, cmd }, "Using package manager for openapi-typescript");
 
+	// No `shell: true` — `specPath` and `typesPath` derive from
+	// `config.output.folder`, a user-controlled string. Passing them through
+	// the shell would allow shell-metacharacter injection. resolveCommand
+	// handles Windows .cmd shims for npx/bunx/etc. Issue #16.
 	const result = spawnSync(
-		cmd,
+		resolveCommand(cmd),
 		[...dlxArgs, "openapi-typescript", specPath, "--output", typesPath],
 		{
 			stdio: "pipe",
 			cwd: process.cwd(),
-			shell: true,
 		}
 	);
 
@@ -1399,14 +1429,54 @@ export type { Paths, HttpMethod, Expand, ExpandRecursively };
 }
 
 /**
+ * Allowed values for `instance.env_accessor`. These flow into the emitted
+ * `api.instance.ts` as raw JS expressions (not string literals), so the
+ * value MUST be a known-safe identifier. Anything else is a code-injection
+ * vector. Issue #17.
+ */
+const ALLOWED_ENV_ACCESSORS = new Set(["process.env", "import.meta.env"]);
+
+/** A bare JavaScript identifier (used for `instance.base_url_env`). */
+const JS_IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
+
+/**
+ * Validates `InstanceConfig` fields that are emitted as raw code (not
+ * string literals) in the generated `api.instance.ts`. Catches malicious
+ * or typo'd config that would otherwise be interpolated into JS.
+ *
+ * - `env_accessor` must be one of the documented accessors.
+ * - `base_url_env` must be a valid JS identifier.
+ *
+ * `token_key` is intentionally not restricted here — it's emitted via
+ * `JSON.stringify`, so any string is safe. Issue #17.
+ */
+function validateInstanceConfigForEmission(config: InstanceConfig): void {
+	if (!ALLOWED_ENV_ACCESSORS.has(config.env_accessor)) {
+		const allowed = [...ALLOWED_ENV_ACCESSORS].map((a) => `"${a}"`).join(", ");
+		throw new GenerationError(
+			"instance",
+			`Invalid env_accessor ${JSON.stringify(config.env_accessor)} — must be one of ${allowed}. Update [instance].env_accessor in api.config.toml.`,
+		);
+	}
+	if (!JS_IDENTIFIER.test(config.base_url_env)) {
+		throw new GenerationError(
+			"instance",
+			`Invalid base_url_env ${JSON.stringify(config.base_url_env)} — must be a valid JavaScript identifier matching /^[A-Za-z_$][\\w$]*$/. Update [instance].base_url_env in api.config.toml.`,
+		);
+	}
+}
+
+/**
  * Generates the auth interceptor block based on auth_mode.
  */
 function generateAuthInterceptor(config: InstanceConfig): string {
 	switch (config.auth_mode) {
 		case "bearer-localstorage":
+			// JSON.stringify the token_key so any `"`, `\`, or control char
+			// in the user's config produces a valid TS string literal. Issue #17.
 			return `
 /** localStorage key for auth token */
-export const tokenKey = "${config.token_key}";
+export const tokenKey = ${JSON.stringify(config.token_key)};
 
 /**
  * Request interceptor that automatically attaches the auth token.
@@ -1464,6 +1534,7 @@ axiosInstance.interceptors.request.use(
  * Generates the api.instance.ts file content.
  */
 export function generateInstanceFileContent(config: InstanceConfig): string {
+	validateInstanceConfigForEmission(config);
 	const authBlock = generateAuthInterceptor(config);
 
 	return `/**

--- a/src/core/pm.ts
+++ b/src/core/pm.ts
@@ -86,10 +86,34 @@ export function getRunCommand(pm: PackageManager): string {
 }
 
 /**
+ * On Windows, common JS package managers (npm, npx, pnpm, yarn, bun, bunx)
+ * ship as `.cmd` shims rather than native `.exe` files. When `child_process`
+ * is invoked without `shell: true`, Node skips PATHEXT resolution, so a
+ * bare command name like `"npm"` fails to launch the shim.
+ *
+ * This helper appends `.cmd` on Windows when the input has no path separator
+ * and no executable extension, letting callers drop `shell: true` (which is
+ * deprecated in Node 24, DEP0190) without losing Windows compatibility.
+ *
+ * On non-Windows platforms, returns the input unchanged.
+ *
+ * Issue #16.
+ */
+export function resolveCommand(cmd: string): string {
+	if (process.platform !== "win32") return cmd;
+	if (cmd.includes("/") || cmd.includes("\\")) return cmd;
+	if (/\.(exe|cmd|bat|ps1)$/i.test(cmd)) return cmd;
+	return `${cmd}.cmd`;
+}
+
+/**
  * Checks whether a command exists on the system PATH.
- * Uses shell: true so Windows can resolve .exe/.cmd wrappers.
+ *
+ * Internal callers only — `cmd` must be a static string. We deliberately
+ * do not pass `shell: true` (deprecated by Node 24 / DEP0190); Windows
+ * `.cmd` shims are handled by `resolveCommand`.
  */
 export function commandExists(cmd: string): boolean {
-	const result = spawnSync(cmd, ["--version"], { stdio: "pipe", shell: true });
+	const result = spawnSync(resolveCommand(cmd), ["--version"], { stdio: "pipe" });
 	return result.status === 0;
 }

--- a/src/headless/runner.ts
+++ b/src/headless/runner.ts
@@ -615,33 +615,33 @@ export async function runHeadless(
 	// Pre-cache openapi-typescript for fetch/generate commands
 	if (command === "fetch" || command === "generate") {
 		const { findProjectRoot } = await import("../core/config.js");
-		const { detectPackageManager, getDlxCommand } = await import(
+		const { detectPackageManager, getDlxCommand, resolveCommand } = await import(
 			"../core/pm.js"
 		);
 		try {
 			const projectRoot = await findProjectRoot();
 			const pm = await detectPackageManager(projectRoot);
 			const [dlxCmd, ...dlxArgs] = getDlxCommand(pm);
+			// Drop `shell: true` (Node 24 DEP0190); resolveCommand handles
+			// Windows .cmd shims. Issue #16.
 			const check = spawnSync(
-				dlxCmd,
+				resolveCommand(dlxCmd),
 				[...dlxArgs, "openapi-typescript", "--version"],
 				{
 					cwd: projectRoot,
 					stdio: "pipe",
 					timeout: 30_000,
-					shell: true,
 				},
 			);
 			if (check.status !== 0) {
 				// Force download by running --help
 				spawnSync(
-					dlxCmd,
+					resolveCommand(dlxCmd),
 					[...dlxArgs, "openapi-typescript", "--help"],
 					{
 						cwd: projectRoot,
 						stdio: "pipe",
 						timeout: 60_000,
-						shell: true,
 					},
 				);
 			}

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { resolve, dirname } from "node:path";
-import { commandExists } from "./core/pm.js";
+import { commandExists, resolveCommand } from "./core/pm.js";
 
 /**
  * Check if Bun is available on the system.
@@ -20,10 +20,13 @@ function relaunchWithBun(argv: string[]): boolean {
 	const binDir = resolve(dirname(thisFile), "..", "bin");
 	const tsEntry = resolve(binDir, "chowbea-axios.ts");
 
-	const result = spawnSync("bun", [tsEntry, ...argv.slice(2)], {
+	// No `shell: true` — user argv flows through here, and shell metacharacters
+	// in user-supplied args (e.g. paths from automation) would otherwise be
+	// interpreted by the shell. resolveCommand handles Windows .cmd shims.
+	// Issue #16.
+	const result = spawnSync(resolveCommand("bun"), [tsEntry, ...argv.slice(2)], {
 		stdio: "inherit",
 		env: process.env,
-		shell: true,
 	});
 
 	if (result.error) return false;

--- a/src/tui/main.tsx
+++ b/src/tui/main.tsx
@@ -10,6 +10,7 @@ import {
 	detectPackageManager,
 	getDlxCommand,
 	getInstallCommand,
+	resolveCommand,
 } from "../core/pm.js";
 
 /**
@@ -51,12 +52,13 @@ async function installPackage(
 ): Promise<void> {
 	console.log(`Installing ${pkg}...`);
 	const pm = await detectPackageManager(projectRoot);
+	// Drop `shell: true` (Node 24 DEP0190); resolveCommand handles
+	// Windows .cmd shims. Issue #16.
 	const [cmd, ...args] = getInstallCommand(pm, pkg, dev);
-	spawnSync(cmd, args, {
+	spawnSync(resolveCommand(cmd), args, {
 		cwd: projectRoot,
 		stdio: "inherit",
 		timeout: 60_000,
-		shell: true,
 	});
 }
 
@@ -67,26 +69,25 @@ async function ensureOpenApiTypescript(projectRoot: string): Promise<void> {
 	const pm = await detectPackageManager(projectRoot);
 	const [cmd, ...dlxArgs] = getDlxCommand(pm);
 
-	// Quick check: try running with --version to see if it's cached
+	// Drop `shell: true` (Node 24 DEP0190); resolveCommand handles
+	// Windows .cmd shims. Issue #16.
 	const check = spawnSync(
-		cmd,
+		resolveCommand(cmd),
 		[...dlxArgs, "openapi-typescript", "--version"],
 		{
 			cwd: projectRoot,
 			stdio: "pipe",
 			timeout: 30_000,
-			shell: true,
 		},
 	);
 
 	if (check.status !== 0) {
 		console.log("Pre-caching openapi-typescript (used for type generation)...");
 		// Run it once so dlx/npx caches the package
-		spawnSync(cmd, [...dlxArgs, "openapi-typescript", "--help"], {
+		spawnSync(resolveCommand(cmd), [...dlxArgs, "openapi-typescript", "--help"], {
 			cwd: projectRoot,
 			stdio: "pipe",
 			timeout: 60_000,
-			shell: true,
 		});
 	}
 }
@@ -113,11 +114,12 @@ async function ensureProjectDependencies(): Promise<void> {
 				);
 				process.exit(1);
 			}
-			spawnSync(pm, ["install"], {
+			// Drop `shell: true` (Node 24 DEP0190); resolveCommand handles
+			// Windows .cmd shims. Issue #16.
+			spawnSync(resolveCommand(pm), ["install"], {
 				cwd: projectRoot,
 				stdio: "inherit",
 				timeout: 120_000,
-				shell: true,
 			});
 		}
 

--- a/src/tui/services/process-manager.ts
+++ b/src/tui/services/process-manager.ts
@@ -57,6 +57,14 @@ class ProcessManager {
 			[pathKey]: `${binDir}${delimiter}${existingPath}`,
 		};
 
+		// `shell: true` is intentional and unavoidable here: `entry.command` is
+		// a user-supplied npm/pnpm/yarn/bun script string from the consumer's
+		// own package.json (e.g. `npm run dev` or `cd foo && bun start`).
+		// Running these requires shell-level parsing of `&&`, redirections,
+		// env-var assignments, and PATHEXT resolution. This is the legitimate
+		// use of shell:true; the deprecation in DEP0190 targets static-arg
+		// invocations elsewhere in the codebase, which have been removed.
+		// Issue #16.
 		const child = spawn(entry.command, [], {
 			cwd: projectRoot,
 			env,

--- a/tests/generator.test.snap
+++ b/tests/generator.test.snap
@@ -984,7 +984,7 @@ exports[`generator: end-to-end snapshots > edge-cases — kebab/snake collision,
 /* ~ =================================== ~ */
 
 /**
-  * A user. Description containing */ injection attempt — issue #14.
+  * A user. Description containing *\\/ injection attempt — issue #14.
  * Schema: User
  */
 export interface User {
@@ -1031,7 +1031,7 @@ export type List_itemsResponse200 = {
 /** Response: GET /items (happy path) */
 export type List_itemsResponse = List_itemsResponse200;
 
-/** Response: POST /items (201 - Created. Description with */ in it.) */
+/** Response: POST /items (201 - Created. Description with *\\/ in it.) */
 export type Create_itemResponse201 = {
 	id?: number;
 	tags?: string[];
@@ -1161,7 +1161,7 @@ type RequestConfig<Q> = Omit<AxiosRequestConfig, "params"> & {
 export const createOperations = (apiClient: any) => ({
   /**
    * Get user by id (kebab-case operationId — issue #13)
-   * Multi-line description containing */ comment-break attempt (issue #14).
+   * Multi-line description containing *\\/ comment-break attempt (issue #14).
    * 
    * @operationId get-user
    * @method GET
@@ -1170,7 +1170,7 @@ export const createOperations = (apiClient: any) => ({
   "get-user": (pathParams: Get_userPathParams, config?: AxiosRequestConfig): Promise<Result<Get_userResponse>> => apiClient.get("/users/{id}", pathParams, config),
 
   /**
-   * Wildcard media type (*/*) — relies on pickJsonContent fallback
+   * Wildcard media type (*\\/*) — relies on pickJsonContent fallback
    * 
    * @operationId list-items
    * @method GET

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -111,24 +111,88 @@ describe("generator: known-bug regression markers", () => {
 		}
 	});
 
-	it.fails("#14: descriptions containing `*/` must not break JSDoc comments", async () => {
+	it("#14 (FIXED): descriptions containing `*/` do not break JSDoc comments", async () => {
 		const spec = await loadFixture("edge-cases.json");
 		const { contracts, operations, cleanup } = await runGenerator(spec);
 		try {
-			// After fix, raw `*/` should not appear inside the body of any
-			// JSDoc block. Today the contracts file leaks `*/ injection in
-			// description` into code position.
-			const body = contracts + "\n" + operations;
-			// Look for `*/` followed by anything but whitespace+end-of-comment-block
-			const lines = body.split("\n");
-			for (const line of lines) {
-				// Allow legitimate comment terminators (a line that's just */ optionally indented)
-				if (/^\s*\*\/\s*$/.test(line)) continue;
-				expect(line).not.toMatch(/\*\//);
-			}
+			// The fixture's User schema description is:
+			//   "A user. Description containing */ injection attempt — issue #14."
+			// Pre-fix, the unescaped `*/` closed the JSDoc block early and the
+			// trailing text leaked into code position. Post-fix, the entire
+			// description is preserved with `*/` rewritten to `*\/`, and no
+			// part of the description appears outside a comment.
+			//
+			// Specific assertions:
+			// - The escaped form `*\/` appears (proving the helper ran).
+			expect(contracts).toMatch(/\*\\\//);
+			// - The danger string after the `*/` (`injection attempt`) never
+			//   appears as bare code — only as part of a comment line that
+			//   begins with whitespace and `*` (the `*` of the JSDoc body).
+			const checkLeak = (body: string) => {
+				const leakingLines = body
+					.split("\n")
+					.filter((line) => /injection attempt/.test(line))
+					.filter((line) => !/^\s*\*\s/.test(line));
+				expect(leakingLines).toEqual([]);
+			};
+			checkLeak(contracts);
+			checkLeak(operations);
 		} finally {
 			await cleanup();
 		}
+	});
+
+	it("#17 (FIXED): generateInstanceFileContent rejects malicious env_accessor", async () => {
+		const { generateInstanceFileContent } = await import(
+			"../src/core/generator.js"
+		);
+		const { DEFAULT_INSTANCE_CONFIG } = await import(
+			"../src/core/config.js"
+		);
+		expect(() =>
+			generateInstanceFileContent({
+				...DEFAULT_INSTANCE_CONFIG,
+				env_accessor: 'process.env); throw new Error("pwn"); //',
+			}),
+		).toThrow(/Invalid env_accessor/);
+	});
+
+	it("#17 (FIXED): generateInstanceFileContent rejects malicious base_url_env", async () => {
+		const { generateInstanceFileContent } = await import(
+			"../src/core/generator.js"
+		);
+		const { DEFAULT_INSTANCE_CONFIG } = await import(
+			"../src/core/config.js"
+		);
+		expect(() =>
+			generateInstanceFileContent({
+				...DEFAULT_INSTANCE_CONFIG,
+				base_url_env: 'API_URL; require("fs").writeFileSync("/tmp/pwn", "x"); var x = "',
+			}),
+		).toThrow(/Invalid base_url_env/);
+	});
+
+	it("#17 (FIXED): generateInstanceFileContent emits tokenKey via JSON.stringify so quotes/backslashes can't escape the literal", async () => {
+		const { generateInstanceFileContent } = await import(
+			"../src/core/generator.js"
+		);
+		const { DEFAULT_INSTANCE_CONFIG } = await import(
+			"../src/core/config.js"
+		);
+		const out = generateInstanceFileContent({
+			...DEFAULT_INSTANCE_CONFIG,
+			auth_mode: "bearer-localstorage",
+			token_key: 'foo"; throw 0; var x = "bar',
+		});
+		// The dangerous payload must appear escaped inside a single string
+		// literal. JSON.stringify escapes the embedded `"` to `\"`, so the
+		// literal stays intact end-to-end.
+		expect(out).toMatch(/export const tokenKey = "foo\\"; throw 0; var x = \\"bar";/);
+		// And there should be exactly one `tokenKey =` in the file (not two —
+		// which would happen if the payload broke out of the literal and
+		// declared its own).
+		const tokenKeyMatches = out.match(/tokenKey\s*=/g) ?? [];
+		expect(tokenKeyMatches).toHaveLength(1);
 	});
 
 	it("#15 (FIXED): enum string values containing `\"` or `\\` are properly escaped", async () => {


### PR DESCRIPTION
## Summary
Three independent input-sanitization gaps where untrusted strings crossed into emitted code or child-process invocations.

Closes #14 · Closes #16 · Closes #17

> ⚠️ **Stacked PR**: based on `fix/generator-emission` (#49), which is based on `test/generator-snapshots` (#48). Merge order: #48 → #49 → #50.

## What's fixed

### #14 — Escape `*/` in JSDoc emissions
A spec author (or compromised remote spec) including `*/` inside any description/summary/path closed the JSDoc comment block early and leaked the rest of the string into the file as raw TypeScript syntax — at best a parse error, at worst arbitrary code at consumer build/run time.

- New `escapeJsdoc(s)` helper rewrites `*/` to `*\/` (preserves visible content; parser no longer matches the terminator).
- Applied at every JSDoc interpolation site: operation summary/description/operationId, schemaToTS prop docs, contracts file's schema-name/description/prop-doc/per-status/body/path/query paths.
- Also switched generated `apiClient.METHOD(...)` calls to use `JSON.stringify(pathTemplate)` so a `"` or `\` in a path can't escape the string literal either.

### #17 — Validate config-string fields entering codegen
`token_key`, `env_accessor`, and `base_url_env` flowed unsanitized into the generated `api.instance.ts`. A malicious `api.config.toml` could inject arbitrary JS into the consumer's emitted code via any of these fields.

- `env_accessor` allowlist: `"process.env"` or `"import.meta.env"` — values flow as raw JS expressions, so any other string is a code-injection vector.
- `base_url_env` validated against `^[A-Za-z_$][\w$]*$` — must be a bare JS identifier.
- `token_key` emitted via `JSON.stringify` — any string is now safe because escaping is mechanized.
- Validation runs at the generator boundary (`generateInstanceFileContent`) so even programmatic callers can't bypass it.

### #16 — Drop `shell: true` from internal spawn calls
Node 24 warns DEP0190 on every `shell: true` invocation. Dropped from 8 call sites:

| File | What it spawns |
|---|---|
| `src/router.ts` | Bun relaunch (user argv flows through) |
| `src/core/pm.ts` | `commandExists` probe |
| `src/core/generator.ts` | openapi-typescript dlx (args from user config) |
| `src/core/actions/init.ts` × 3 | axios install, concurrently install, initial fetch |
| `src/headless/runner.ts` × 2 | openapi-typescript pre-cache |
| `src/tui/main.tsx` × 4 | auto-install + pre-cache + fallback install |

New `resolveCommand(cmd)` helper in `pm.ts` appends `.cmd` on Windows for bare command names so npm/pnpm/yarn/bun/npx/bunx still launch via their shim files without `shell: true` (Node otherwise skips PATHEXT resolution).

**Kept** `shell: true` at `src/tui/services/process-manager.ts:71` with explicit justification: running user-supplied package.json scripts (which may include `&&`, redirections, env-var assignments) is the legitimate use of a shell.

## Tests

- Flipped `it.fails()` markers for #14 and #17.
- Added three #17 tests: rejects malicious `env_accessor`, rejects malicious `base_url_env`, verifies `token_key` round-trips through `JSON.stringify` with no payload escape.
- Snapshots refreshed; diff shows escaped `*\/` in the User schema description and `JSON.stringify`'d path literals throughout `api.operations.ts`.

```
Test Files  2 passed (2)
     Tests  35 passed | 5 expected fail (40)
```

The 5 remaining expected-fails are unfixed bugs tracked separately (#19, #26, #31, #32, plus a duplicate ref-utils #19 marker) — they'll flip in their respective PRs.

## End-to-end smoke test

`.context/smoke-test/tricky-spec.json` exercises kebab-case operationIds, descriptions with `*/` injection, enum values with `"` and `\`, the `*/*` media type, recursive types, multipart with ambiguous field names, and `additionalProperties`.

```
chowbea-axios fetch  →  tsc --noEmit  →  exit 0
```

The same spec produced 30+ syntax errors at the start of the package review. After Phase 1 (PR #48 + PR #49 + this PR), it compiles cleanly. **Phase 1 headline goal met.**

## Test plan
- [ ] `npm test` passes (35 / 5 expected fail)
- [ ] `npm run build` clean
- [ ] Manual: malicious `token_key`/`env_accessor`/`base_url_env` in api.config.toml → clear validation error
- [ ] Manual: spec with `*/` in a description → emits escaped `*\/` and compiles
- [ ] Manual: `chowbea-axios init` end-to-end on macOS, Linux, Windows — validates `resolveCommand` works in practice

🤖 Generated with [Claude Code](https://claude.com/claude-code)