### PR TITLE
fix(ref-utils): decode RFC 6901 JSON Pointer escapes

### DIFF
--- a/src/core/ref-utils.ts
+++ b/src/core/ref-utils.ts
@@ -31,19 +31,51 @@ export const MAX_SCHEMA_DEPTH = 8;
 // ---------------------------------------------------------------------------
 
 /**
+ * Per [RFC 6901 §4](https://datatracker.ietf.org/doc/html/rfc6901#section-4):
+ * "decoding any escaped character sequence" requires transforming `~1` to `/`
+ * **before** transforming `~0` to `~`. Reversing the order would incorrectly
+ * decode `~01` to `/` (via `~0` → `~`, then `~1` → `/`) instead of the
+ * required `~1`.
+ */
+function unescapeJsonPointerSegment(segment: string): string {
+	return segment.replace(/~1/g, "/").replace(/~0/g, "~");
+}
+
+/**
+ * Property names that, if followed via bracket access, would resolve to
+ * built-in prototype machinery rather than spec content. Refusing them at
+ * the resolver eliminates a class of bugs (and a faint prototype-pollution
+ * surface) when handling untrusted specs.
+ */
+const FORBIDDEN_REF_SEGMENTS = new Set(["__proto__", "prototype", "constructor"]);
+
+/**
  * Follows a `$ref` JSON pointer (e.g. `#/components/schemas/Foo`) through
  * the spec object and returns the resolved value.
+ *
+ * Decodes RFC 6901 escape sequences (`~1` → `/`, `~0` → `~`) so refs
+ * like `#/paths/~1users~1{id}/get` resolve correctly. Issue #19.
  */
 export function resolveRef(ref: string, spec: unknown): unknown {
 	if (typeof ref !== "string" || !ref.startsWith("#/")) {
 		return undefined;
 	}
 
-	const segments = ref.slice(2).split("/");
+	const segments = ref.slice(2).split("/").map(unescapeJsonPointerSegment);
 	let current: unknown = spec;
 
 	for (const segment of segments) {
 		if (current === null || current === undefined || typeof current !== "object") {
+			return undefined;
+		}
+		// Refuse prototype-machinery segments. A spec author writing
+		// `#/__proto__` would otherwise resolve to Object.prototype.
+		if (FORBIDDEN_REF_SEGMENTS.has(segment)) {
+			return undefined;
+		}
+		// Use Object.hasOwn to avoid traversing inherited properties even if
+		// the resolved object somehow has a prototype-chain match.
+		if (!Object.hasOwn(current as object, segment)) {
 			return undefined;
 		}
 		current = (current as Record<string, unknown>)[segment];
@@ -71,12 +103,14 @@ export function resolveObject(
 }
 
 /**
- * Extracts the last segment of a `$ref` path as a human-readable name.
+ * Extracts the last segment of a `$ref` path as a human-readable name,
+ * decoded per RFC 6901 (so `weird~1name` becomes `weird/name`).
  * e.g. `#/components/schemas/UserDto` -> `UserDto`
  */
 export function refName(ref: string): string {
 	const segments = ref.split("/");
-	return segments[segments.length - 1] ?? ref;
+	const last = segments[segments.length - 1] ?? ref;
+	return unescapeJsonPointerSegment(last);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/ref-utils.test.ts
+++ b/tests/ref-utils.test.ts
@@ -36,24 +36,49 @@ describe("resolveRef", () => {
 		expect(resolveRef(123 as unknown as string, spec)).toBeUndefined();
 	});
 
-	// Issue #19: JSON Pointer escape sequences ~0 (~) and ~1 (/) are not decoded.
-	it.fails("#19: decodes ~1 to '/' per RFC 6901", () => {
+	// Issue #19 (FIXED): JSON Pointer escape sequences ~0 (~) and ~1 (/) are
+	// now decoded per RFC 6901.
+	it("#19 (FIXED): decodes ~1 to '/' per RFC 6901", () => {
 		const refs = {
 			paths: {
 				"/users/{id}": { get: { operationId: "x" } },
 			},
 		};
-		// `#/paths/~1users~1{id}/get` should resolve to the GET operation.
+		// `#/paths/~1users~1{id}/get` resolves to the GET operation.
 		expect(resolveRef("#/paths/~1users~1{id}/get", refs)).toEqual({
 			operationId: "x",
 		});
 	});
 
-	it.fails("#19: decodes ~0 to '~' per RFC 6901", () => {
+	it("#19 (FIXED): decodes ~0 to '~' per RFC 6901", () => {
 		const refs = { components: { schemas: { "weird~name": { type: "string" } } } };
 		expect(resolveRef("#/components/schemas/weird~0name", refs)).toEqual({
 			type: "string",
 		});
+	});
+
+	it("#19 (FIXED): handles RFC 6901's ~01 over-decoding hazard correctly", () => {
+		// Per RFC 6901 §4: `~01` must decode to `~1`, not to `/`.
+		// A naive "do ~0 first" implementation would produce `~1` → `/` (wrong).
+		// The correct order is `~1` → `/`, then `~0` → `~`, leaving the RFC
+		// example `~01` as `~1`.
+		const refs = { foo: { "~1": "found" } };
+		expect(resolveRef("#/foo/~01", refs)).toBe("found");
+	});
+
+	// Defense in depth: don't traverse prototype machinery via JSON Pointer.
+	it("refuses prototype-pollution segments", () => {
+		const spec = {};
+		expect(resolveRef("#/__proto__", spec)).toBeUndefined();
+		expect(resolveRef("#/constructor", spec)).toBeUndefined();
+		expect(resolveRef("#/__proto__/polluted", spec)).toBeUndefined();
+	});
+
+	// Even when an inherited property exists, refuse to surface it.
+	it("only resolves own properties", () => {
+		const spec = Object.create({ inherited: "from-prototype" });
+		// `inherited` is on the prototype, not the spec itself.
+		expect(resolveRef("#/inherited", spec)).toBeUndefined();
 	});
 });
 
@@ -64,6 +89,11 @@ describe("refName", () => {
 
 	it("falls back to the full ref for unparseable inputs", () => {
 		expect(refName("not-a-ref")).toBe("not-a-ref");
+	});
+
+	it("decodes RFC 6901 escapes in the displayed name", () => {
+		expect(refName("#/components/schemas/weird~0name")).toBe("weird~name");
+		expect(refName("#/paths/~1users~1{id}")).toBe("/users/{id}");
 	});
 });
 


### PR DESCRIPTION
## Summary
Closes #19.

Per [RFC 6901 §4](https://datatracker.ietf.org/doc/html/rfc6901#section-4), the reference token sequences `~1` (`/`) and `~0` (`~`) MUST be decoded before lookup, in that order. Reversing the order mis-decodes the canonical example `~01` into `/` instead of `~1`.

`resolveRef` was treating segments as opaque strings — any spec writing a legitimate escaped ref like `#/paths/~1users~1{id}/get` got `undefined` back, triggering false "unresolved $ref" warnings in `validate` and `unknown` types in the generator output.

> ⚠️ **Stacked PR**: based on `security/input-sanitization` (#50). Merge order: #48 → #49 → #50 → this.

## Changes
- New `unescapeJsonPointerSegment(seg)` applying `~1` → `/` then `~0` → `~`.
- `resolveRef` decodes each segment before lookup.
- `refName` decodes the displayed last segment so `weird~1name` shows as `weird/name`.
- **Hardening**: refuses `__proto__`/`prototype`/`constructor` segments to prevent prototype-machinery traversal, and uses `Object.hasOwn` so inherited properties are never returned even if a resolved subtree has a prototype chain.

## Tests
- Flipped both `#19` `it.fails()` markers to passing `it()`.
- Added RFC 6901 `~01` over-decoding hazard test (validates the order is correct).
- Added two prototype-pollution tests (forbidden segments + inherited-only properties).
- Added `refName` decoded-display tests.

```
Test Files  2 passed (2)
     Tests  41 passed | 3 expected fail (44)
```

The 3 remaining expected-fails are #26 (recursion), #31 (HTTP methods), #32 (additionalProperties) — tracked separately in upcoming PRs.

## Test plan
- [ ] `npm test` passes (41 / 3 expected fail)
- [ ] `npm run build` clean
- [ ] Manual: a spec with a path-item `$ref: '#/paths/~1users/get'` resolves correctly
- [ ] Manual: a spec with `$ref: '#/__proto__'` returns undefined cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)