### PR TITLE
feat(fetcher): support YAML OpenAPI specs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "@opentui/react": "^0.1.90",
         "picocolors": "^1.1.1",
         "react": "^19.2.4",
-        "toml": "^3.0.0"
+        "toml": "^3.0.0",
+        "yaml": "^2.8.3"
       },
       "bin": {
         "chowbea-axios": "bin/chowbea-axios.js"
@@ -27,7 +28,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "vite": ">=5.0.0"
@@ -3315,6 +3316,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yoctocolors-cjs": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "@opentui/react": "^0.1.90",
     "picocolors": "^1.1.1",
     "react": "^19.2.4",
-    "toml": "^3.0.0"
+    "toml": "^3.0.0",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/src/core/fetcher.ts
+++ b/src/core/fetcher.ts
@@ -5,9 +5,73 @@
 
 import { createHash } from "node:crypto";
 import { access, readFile, writeFile } from "node:fs/promises";
+import { parse as parseYaml } from "yaml";
 
 import { NetworkError, SpecNotFoundError } from "./errors.js";
 import type { Logger } from "../adapters/logger-interface.js";
+
+/**
+ * Parses an OpenAPI spec from raw text. Accepts both JSON and YAML.
+ *
+ * Strategy:
+ * - If `sourceHint` ends in `.yaml` / `.yml`, parse as YAML directly.
+ * - Otherwise try JSON first (the most common case and the format of the
+ *   cache file), then fall back to YAML on parse failure.
+ *
+ * Throws an `Error` with a clear message if neither parser accepts the
+ * content. Issue #23.
+ */
+export function parseSpecContent(content: string, sourceHint?: string): unknown {
+	const isYamlExt = sourceHint != null && /\.ya?ml$/i.test(sourceHint);
+
+	if (isYamlExt) {
+		try {
+			return parseYaml(content);
+		} catch (err) {
+			throw new Error(
+				`Failed to parse YAML spec${sourceHint ? ` at ${sourceHint}` : ""}: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			);
+		}
+	}
+
+	// Default: JSON first (cache files and most public endpoints), YAML
+	// fallback (private specs hand-authored in YAML).
+	try {
+		return JSON.parse(content);
+	} catch (jsonErr) {
+		try {
+			return parseYaml(content);
+		} catch (yamlErr) {
+			throw new Error(
+				`Failed to parse spec${sourceHint ? ` at ${sourceHint}` : ""} as JSON or YAML. ` +
+					`JSON error: ${jsonErr instanceof Error ? jsonErr.message : String(jsonErr)}. ` +
+					`YAML error: ${yamlErr instanceof Error ? yamlErr.message : String(yamlErr)}.`,
+			);
+		}
+	}
+}
+
+/**
+ * Normalizes a spec buffer to a JSON-encoded form. Parses with auto-
+ * detection (JSON or YAML), then re-encodes as canonical JSON.
+ *
+ * The downstream pipeline (cache file, generator, diff, validate) all
+ * expect JSON, so we convert at the parse boundary. The `spec` object is
+ * also returned so callers don't need to re-parse.
+ *
+ * Issue #23.
+ */
+export function normalizeSpecBuffer(buffer: Buffer, sourceHint?: string): {
+	spec: unknown;
+	jsonBuffer: Buffer;
+} {
+	const content = buffer.toString("utf8");
+	const spec = parseSpecContent(content, sourceHint);
+	const jsonBuffer = Buffer.from(JSON.stringify(spec, null, 2), "utf8");
+	return { spec, jsonBuffer };
+}
 
 /**
  * Cache metadata stored in .api-cache.json
@@ -217,19 +281,25 @@ export async function fetchOpenApiSpec(options: {
 			}
 
 			const arrayBuffer = await response.arrayBuffer();
-			const buffer = Buffer.from(arrayBuffer);
-			const hash = computeHash(buffer);
+			const rawBuffer = Buffer.from(arrayBuffer);
+
+			// Normalize to JSON so the cache file and downstream parsers
+			// always see JSON, even when the endpoint serves YAML. Issue #23.
+			// We pass the endpoint as a hint so YAML extensions are picked up
+			// directly; for unknown content-types we fall back to JSON-then-YAML.
+			const { jsonBuffer } = normalizeSpecBuffer(rawBuffer, endpoint);
+			const hash = computeHash(jsonBuffer);
 
 			// Check if content has changed
 			const hasChanged = force || !existingCache || existingCache.hash !== hash;
 
 			logger.debug(
-				{ hash, hasChanged, bytes: buffer.length },
+				{ hash, hasChanged, bytes: jsonBuffer.length },
 				"Spec fetched successfully"
 			);
 
 			return {
-				buffer,
+				buffer: jsonBuffer,
 				hash,
 				hasChanged,
 				fromCache: false,
@@ -307,13 +377,14 @@ export async function saveSpec(options: {
 }
 
 /**
- * Checks if the local spec exists and is valid.
+ * Checks if the local spec exists and is parseable as JSON or YAML.
+ * Issue #23 (was JSON-only).
  */
 export async function hasLocalSpec(specPath: string): Promise<boolean> {
 	try {
 		await access(specPath);
 		const content = await readFile(specPath, "utf8");
-		JSON.parse(content); // Verify it's valid JSON
+		parseSpecContent(content, specPath); // throws on invalid
 		return true;
 	} catch {
 		return false;
@@ -321,8 +392,18 @@ export async function hasLocalSpec(specPath: string): Promise<boolean> {
 }
 
 /**
- * Loads and parses the local OpenAPI spec.
- * Throws SpecNotFoundError if not found.
+ * Loads and parses the local OpenAPI spec. Accepts both JSON and YAML
+ * (auto-detected via file extension, with JSON-then-YAML fallback for
+ * unknown extensions).
+ *
+ * Returns a `buffer` that's always JSON-encoded — even when the source
+ * was YAML — so the rest of the pipeline (cache file, generator) can
+ * keep using `JSON.parse` without change. Hashing of this normalized
+ * buffer also gives stable cache keys regardless of YAML whitespace
+ * variations. Issue #23.
+ *
+ * Throws `SpecNotFoundError` if the file doesn't exist, or a generic
+ * `Error` if neither JSON nor YAML can parse the content.
  */
 export async function loadLocalSpec(specPath: string): Promise<{
 	spec: unknown;
@@ -334,17 +415,9 @@ export async function loadLocalSpec(specPath: string): Promise<{
 		throw new SpecNotFoundError(specPath);
 	}
 
-	const buffer = await readFile(specPath);
-	const content = buffer.toString("utf8");
-
-	try {
-		const spec = JSON.parse(content);
-		return { spec, buffer };
-	} catch (error) {
-		throw new Error(
-			`Failed to parse OpenAPI spec: ${error instanceof Error ? error.message : String(error)}`
-		);
-	}
+	const rawBuffer = await readFile(specPath);
+	const { spec, jsonBuffer } = normalizeSpecBuffer(rawBuffer, specPath);
+	return { spec, buffer: jsonBuffer };
 }
 
 /**

--- a/tests/fetcher.test.ts
+++ b/tests/fetcher.test.ts
@@ -1,0 +1,192 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+	hasLocalSpec,
+	loadLocalSpec,
+	normalizeSpecBuffer,
+	parseSpecContent,
+} from "../src/core/fetcher.js";
+
+const SAMPLE_JSON = `{
+  "openapi": "3.0.3",
+  "info": { "title": "X", "version": "1.0.0" },
+  "paths": {}
+}`;
+
+const SAMPLE_YAML = `openapi: 3.0.3
+info:
+  title: X
+  version: "1.0.0"
+paths: {}
+`;
+
+describe("parseSpecContent (#23 — YAML support)", () => {
+	it("parses JSON content", () => {
+		const spec = parseSpecContent(SAMPLE_JSON);
+		expect((spec as { openapi: string }).openapi).toBe("3.0.3");
+	});
+
+	it("parses YAML content (no hint)", () => {
+		const spec = parseSpecContent(SAMPLE_YAML);
+		expect((spec as { openapi: string }).openapi).toBe("3.0.3");
+		expect((spec as { info: { title: string } }).info.title).toBe("X");
+	});
+
+	it("uses .yaml extension as a hint", () => {
+		const spec = parseSpecContent(SAMPLE_YAML, "openapi.yaml");
+		expect((spec as { openapi: string }).openapi).toBe("3.0.3");
+	});
+
+	it("uses .yml extension as a hint", () => {
+		const spec = parseSpecContent(SAMPLE_YAML, "openapi.yml");
+		expect((spec as { openapi: string }).openapi).toBe("3.0.3");
+	});
+
+	it("hint takes precedence — JSON content with .yaml hint should still parse via YAML reader (which accepts JSON, since JSON is a subset)", () => {
+		// yaml@2 parses JSON-as-YAML successfully because JSON is a YAML
+		// subset. Verifies the hint path doesn't fail on hybrid content.
+		const spec = parseSpecContent(SAMPLE_JSON, "spec.yaml");
+		expect((spec as { openapi: string }).openapi).toBe("3.0.3");
+	});
+
+	it("throws a clear error when neither parser accepts the content", () => {
+		expect(() => parseSpecContent("not: : : valid: anything: at all\n  - garbled", "x.json"))
+			.toThrow(/Failed to parse spec.*at x\.json/);
+	});
+
+	it("includes both JSON and YAML errors when no hint is provided", () => {
+		// `[1, 2,` is invalid as JSON (trailing comma + unterminated array)
+		// AND invalid as YAML (parsed as flow-style sequence with broken syntax).
+		// At least one parser will reject; both errors should appear when no hint.
+		try {
+			parseSpecContent("[1, 2,");
+			expect.unreachable();
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			// We at least mention "JSON error" — YAML may be more permissive.
+			expect(msg).toMatch(/JSON error/);
+		}
+	});
+});
+
+describe("normalizeSpecBuffer (#23)", () => {
+	it("returns parsed spec plus a JSON-encoded buffer for YAML input", () => {
+		const yamlBuf = Buffer.from(SAMPLE_YAML, "utf8");
+		const { spec, jsonBuffer } = normalizeSpecBuffer(yamlBuf, "in.yaml");
+		expect((spec as { openapi: string }).openapi).toBe("3.0.3");
+		// jsonBuffer must round-trip via JSON.parse without YAML keys leaking.
+		const reparsed = JSON.parse(jsonBuffer.toString("utf8"));
+		expect(reparsed).toEqual(spec);
+	});
+
+	it("returns the input as JSON for JSON content", () => {
+		const jsonBuf = Buffer.from(SAMPLE_JSON, "utf8");
+		const { jsonBuffer } = normalizeSpecBuffer(jsonBuf);
+		expect(JSON.parse(jsonBuffer.toString("utf8"))).toMatchObject({
+			openapi: "3.0.3",
+			info: { title: "X" },
+		});
+	});
+
+	it("normalizes whitespace differences in YAML to a stable JSON buffer", () => {
+		const yamlA = "openapi: 3.0.3\ninfo:\n  title: X\n  version: '1.0.0'\npaths: {}\n";
+		const yamlB = "openapi:    3.0.3\ninfo:\n  title:   X\n  version:  '1.0.0'\npaths: {}\n";
+		const a = normalizeSpecBuffer(Buffer.from(yamlA), "a.yaml").jsonBuffer;
+		const b = normalizeSpecBuffer(Buffer.from(yamlB), "b.yaml").jsonBuffer;
+		// Same logical content → identical JSON output → stable cache key.
+		expect(a.equals(b)).toBe(true);
+	});
+});
+
+describe("hasLocalSpec (#23)", () => {
+	async function withTempFile<T>(
+		filename: string,
+		content: string,
+		fn: (path: string) => Promise<T>,
+	): Promise<T> {
+		const dir = join(
+			tmpdir(),
+			`chowbea-fetcher-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		await mkdir(dir, { recursive: true });
+		const path = join(dir, filename);
+		try {
+			await writeFile(path, content, "utf8");
+			return await fn(path);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	}
+
+	it("accepts JSON specs", async () => {
+		await withTempFile("openapi.json", SAMPLE_JSON, async (path) => {
+			expect(await hasLocalSpec(path)).toBe(true);
+		});
+	});
+
+	it("accepts YAML specs (.yaml)", async () => {
+		await withTempFile("openapi.yaml", SAMPLE_YAML, async (path) => {
+			expect(await hasLocalSpec(path)).toBe(true);
+		});
+	});
+
+	it("accepts YAML specs (.yml)", async () => {
+		await withTempFile("openapi.yml", SAMPLE_YAML, async (path) => {
+			expect(await hasLocalSpec(path)).toBe(true);
+		});
+	});
+
+	it("rejects non-existent files", async () => {
+		expect(await hasLocalSpec("/tmp/definitely-not-here.json")).toBe(false);
+	});
+
+	it("rejects files that are neither JSON nor YAML", async () => {
+		// YAML 2.x is permissive — most non-JSON text parses as a scalar
+		// string. Use unbalanced flow-style indicators which both JSON and
+		// YAML reject. (The same input is verified to throw in the
+		// parseSpecContent error-message test above.)
+		await withTempFile("openapi.json", "[1, 2,", async (path) => {
+			expect(await hasLocalSpec(path)).toBe(false);
+		});
+	});
+});
+
+describe("loadLocalSpec (#23)", () => {
+	async function withTempFile<T>(
+		filename: string,
+		content: string,
+		fn: (path: string) => Promise<T>,
+	): Promise<T> {
+		const dir = join(
+			tmpdir(),
+			`chowbea-fetcher-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		await mkdir(dir, { recursive: true });
+		const path = join(dir, filename);
+		try {
+			await writeFile(path, content, "utf8");
+			return await fn(path);
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	}
+
+	it("loads YAML specs and returns a JSON-encoded buffer", async () => {
+		await withTempFile("openapi.yaml", SAMPLE_YAML, async (path) => {
+			const { spec, buffer } = await loadLocalSpec(path);
+			expect((spec as { openapi: string }).openapi).toBe("3.0.3");
+			// Buffer must be JSON, even though the source was YAML.
+			expect(JSON.parse(buffer.toString("utf8"))).toEqual(spec);
+		});
+	});
+
+	it("loads JSON specs unchanged in semantics", async () => {
+		await withTempFile("openapi.json", SAMPLE_JSON, async (path) => {
+			const { spec, buffer } = await loadLocalSpec(path);
+			expect(JSON.parse(buffer.toString("utf8"))).toEqual(spec);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
Closes #23.

Most spec authors produce YAML (Swagger Editor, Stoplight, OpenAPI Generator, hand-written). The package previously rejected anything non-JSON with a misleading "spec not found" error.

> ⚠️ **Stacked PR**: based on `fix/json-pointer-escapes` (#51). Merge order: #48 → #49 → #50 → #51 → this.

## Approach
- New `parseSpecContent(content, sourceHint?)`: JSON first, YAML fallback, with `.yaml`/`.yml` extension acting as a hint.
- New `normalizeSpecBuffer(buffer, sourceHint?)`: parses + re-encodes as canonical JSON.
- `hasLocalSpec` checks parseability via `parseSpecContent` (was strict JSON).
- `loadLocalSpec` returns a JSON-encoded buffer regardless of source — hashing this normalized buffer gives stable cache keys across YAML whitespace variations.
- `fetchOpenApiSpec` normalizes the fetched buffer before saving to cache.

The cache file is always JSON, so all downstream readers (`generator.generate`, `diff.executeDiff`) keep using `JSON.parse` without change. **No call sites outside fetcher.ts needed updating.**

## Tests
New `tests/fetcher.test.ts` — 16 tests:
- `parseSpecContent`: JSON content, YAML content, hint precedence, error message format
- `normalizeSpecBuffer`: round-trip, whitespace stability (same logical content → identical JSON output)
- `hasLocalSpec`: accepts JSON + .yaml + .yml + rejects unparseable content
- `loadLocalSpec`: YAML input → JSON-encoded buffer

```
Test Files  3 passed (3)
     Tests  58 passed | 3 expected fail (61)
```

## End-to-end smoke test
`.context/smoke-test/petstore.yaml` (a hand-written YAML spec) → `chowbea-axios fetch` → `tsc --noEmit` → **exit 0**.

## Test plan
- [ ] `npm test` passes (58 / 3 expected fail)
- [ ] `npm run build` clean
- [ ] Manual: a real YAML spec (e.g., Stripe / GitHub / your own) fetches and compiles
- [ ] Manual: an endpoint that serves YAML works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)