### PR TITLE
fix(generator): recursion + additionalProperties in schemaToTS

### DIFF
--- a/src/core/generator.ts
+++ b/src/core/generator.ts
@@ -644,9 +644,51 @@ function resolveRefName(ref: string): string | null {
 }
 
 /**
+ * Renders `additionalProperties` as a `Record<string, T>` clause, or
+ * `null` when no additional-properties contract applies. Issue #32.
+ *
+ * - `true` / any truthy non-object  → `Record<string, unknown>`
+ * - schema object (e.g. `{ type: "string" }`) → `Record<string, T>`
+ *   where `T` is recursively rendered.
+ * - `false` / `undefined`           → `null` (closed shape; no clause)
+ */
+function renderAdditionalProperties(
+	additionalProperties: unknown,
+	indent: string,
+	allSchemas: Record<string, unknown>,
+	visited: Set<string>,
+): string | null {
+	if (additionalProperties === undefined || additionalProperties === false) {
+		return null;
+	}
+	if (additionalProperties === true) {
+		return "Record<string, unknown>";
+	}
+	if (typeof additionalProperties === "object" && additionalProperties !== null) {
+		const valueType = schemaToTS(
+			additionalProperties as Record<string, unknown>,
+			indent,
+			allSchemas,
+			visited,
+		);
+		// Wrap unions/intersections so the Record value type parses cleanly.
+		const needsParens = valueType.includes(" | ") || valueType.includes(" & ");
+		return `Record<string, ${needsParens ? `(${valueType})` : valueType}>`;
+	}
+	return null;
+}
+
+/**
  * Converts a JSON Schema to a fully-expanded TypeScript type string.
- * Recursively inlines $ref schemas so every type is visible without indirection.
- * Uses a visited set to detect circular references (falls back to `unknown` for cycles).
+ * Recursively inlines $ref schemas so every type is visible without
+ * indirection.
+ *
+ * For recursive schemas (a `$ref` whose target is already on the
+ * inlining stack), emits the sanitized type name from the contracts
+ * file rather than collapsing to `unknown`. The contracts file emits
+ * a top-level `export interface <Name>` for every entry in
+ * `components.schemas`, so the named reference resolves at TS compile
+ * time. Issue #26.
  */
 function schemaToTS(
 	schema: Record<string, unknown>,
@@ -656,11 +698,13 @@ function schemaToTS(
 ): string {
 	if (!schema || typeof schema !== "object") return "unknown";
 
-	// $ref → recursively inline the referenced schema
+	// $ref → recursively inline the referenced schema. On cycles, emit
+	// the sanitized name (the contracts file has a top-level interface
+	// for it) instead of collapsing to `unknown`. Issue #26.
 	if (schema.$ref && typeof schema.$ref === "string") {
 		const refName = resolveRefName(schema.$ref);
 		if (!refName) return "unknown";
-		if (visited.has(refName)) return "unknown"; // circular ref guard
+		if (visited.has(refName)) return sanitizeIdentifier(refName);
 		const refSchema = allSchemas[refName] as Record<string, unknown> | undefined;
 		if (!refSchema) return "unknown";
 		const newVisited = new Set(visited);
@@ -699,12 +743,29 @@ function schemaToTS(
 		return needsParens ? `(${itemType})[]` : `${itemType}[]`;
 	}
 
-	// object with properties → inline object type
+	// object with properties → inline object type. Honors
+	// `additionalProperties` per OpenAPI / JSON Schema:
+	//   - true (or any non-false truthy)             → Record<string, unknown>
+	//   - schema (e.g. { type: "string" })           → Record<string, T>
+	//   - false / undefined / explicit closed shape  → no record intersection
+	// Combined with named properties, the open-shape becomes an
+	// intersection (`{ ... } & Record<string, T>`). Issue #32.
 	if (schemaType === "object" || schema.properties) {
 		const properties = schema.properties as Record<string, Record<string, unknown>> | undefined;
+		const additionalType = renderAdditionalProperties(
+			schema.additionalProperties,
+			indent,
+			allSchemas,
+			visited,
+		);
+
 		if (!properties || Object.keys(properties).length === 0) {
-			return "Record<string, unknown>";
+			// No named properties — an open object collapses to a Record.
+			// `additionalProperties: false` is meaningless without props,
+			// so default to `Record<string, unknown>` if not specified.
+			return additionalType ?? "Record<string, unknown>";
 		}
+
 		const required = new Set<string>(Array.isArray(schema.required) ? schema.required as string[] : []);
 		const innerIndent = indent + "\t";
 		const props = Object.entries(properties).map(([key, propSchema]) => {
@@ -715,7 +776,8 @@ function schemaToTS(
 				: "";
 			return `${desc}${formatPropertyKey(key)}${optional}: ${propType};`;
 		});
-		return `{\n${innerIndent}${props.join(`\n${innerIndent}`)}\n${indent}}`;
+		const objectType = `{\n${innerIndent}${props.join(`\n${innerIndent}`)}\n${indent}}`;
+		return additionalType ? `${objectType} & ${additionalType}` : objectType;
 	}
 
 	// primitive types

--- a/tests/generator.test.snap
+++ b/tests/generator.test.snap
@@ -995,7 +995,7 @@ export interface User {
 		id: string;
 		name: string;
 		email?: string;
-		friends?: unknown[];
+		friends?: User[];
 	}[];
 }
 
@@ -1016,7 +1016,7 @@ export type Get_userResponse200 = {
 	id: string;
 	name: string;
 	email?: string;
-	friends?: unknown[];
+	friends?: User[];
 };
 
 /** Response: GET /users/{id} (happy path) */
@@ -1043,7 +1043,7 @@ export type Create_itemResponse = Create_itemResponse201;
 /** Response: GET /dictionary (200 - OK) */
 export type Get_dictionaryResponse200 = {
 	id?: string;
-};
+} & Record<string, string>;
 
 /** Response: GET /dictionary (happy path) */
 export type Get_dictionaryResponse = Get_dictionaryResponse200;

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -263,13 +263,15 @@ describe("generator: known-bug regression markers", () => {
 		}
 	});
 
-	it.fails("#26: recursive types should reference themselves, not collapse to unknown[]", async () => {
+	it("#26 (FIXED): recursive types reference themselves instead of collapsing to unknown[]", async () => {
 		const spec = await loadFixture("edge-cases.json");
 		const { contracts, cleanup } = await runGenerator(spec);
 		try {
-			// Today emits `friends?: unknown[]`.
-			// After fix: `friends?: User[]` (or some self-referential alias).
+			// `User.friends` recurses into User; on the cycle we now emit
+			// the sanitized name, which the contracts file already exports
+			// as a top-level interface.
 			expect(contracts).not.toMatch(/friends\?:\s*unknown\[\]/);
+			expect(contracts).toMatch(/friends\?:\s*User\[\]/);
 		} finally {
 			await cleanup();
 		}
@@ -380,14 +382,83 @@ describe("generator: known-bug regression markers", () => {
 		}
 	});
 
-	it.fails("#32: additionalProperties should not be silently dropped", async () => {
+	it("#32 (FIXED): additionalProperties produces a Record<string, T> intersection", async () => {
 		const spec = await loadFixture("edge-cases.json");
 		const { contracts, cleanup } = await runGenerator(spec);
 		try {
-			// `/dictionary` GET response has additionalProperties: { type: string }.
-			// After fix: emitted type should include `Record<string, string>` or
-			// an index signature `[key: string]: string`.
-			expect(contracts).toMatch(/Record<string,\s*string>|\[key:\s*string\]:\s*string/);
+			// `/dictionary` GET response has additionalProperties: { type: string }
+			// alongside a named `id` property. The emitted type combines
+			// `{ id?: string }` with `Record<string, string>`.
+			expect(contracts).toMatch(/Record<string,\s*string>/);
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("#32 (FIXED): additionalProperties: true emits Record<string, unknown>", async () => {
+		const spec = {
+			openapi: "3.0.3",
+			info: { title: "X", version: "1.0.0" },
+			paths: {
+				"/x": {
+					get: {
+						operationId: "get-x",
+						responses: {
+							"200": {
+								description: "OK",
+								content: {
+									"application/json": {
+										schema: {
+											type: "object",
+											additionalProperties: true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		};
+		const { contracts, cleanup } = await runGenerator(spec);
+		try {
+			expect(contracts).toMatch(/Record<string,\s*unknown>/);
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("#32 (FIXED): additionalProperties: false leaves a closed object", async () => {
+		const spec = {
+			openapi: "3.0.3",
+			info: { title: "X", version: "1.0.0" },
+			paths: {
+				"/x": {
+					get: {
+						operationId: "get-x",
+						responses: {
+							"200": {
+								description: "OK",
+								content: {
+									"application/json": {
+										schema: {
+											type: "object",
+											properties: { id: { type: "string" } },
+											additionalProperties: false,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		};
+		const { contracts, cleanup } = await runGenerator(spec);
+		try {
+			// Closed shape — no Record intersection emitted.
+			expect(contracts).toMatch(/Get_xResponse200 = \{[^&]*\};/s);
+			expect(contracts).not.toMatch(/Get_xResponse200.*Record</s);
 		} finally {
 			await cleanup();
 		}


### PR DESCRIPTION
## Summary
Closes #26.
Closes #32 (the `additionalProperties` leg).

Broader `$ref`-kind support (refs to `components.parameters`/`requestBodies`/`responses`) is tracked as a follow-up; this PR addresses the high-impact `additionalProperties` gap.

> ⚠️ **Stacked PR**: based on `fix/spec-method-coverage` (#53). Merge order: #48 → #49 → #50 → #51 → #52 → #53 → this.

## #26 — Recursive types

`schemaToTS` previously returned `"unknown"` on every cycle hit, so a self-referential `User { friends: User[] }` produced `friends?: unknown[]` — total type loss.

The contracts file already emits a top-level `export interface User` for every `components.schemas` entry, so the named ref is in scope. Now `schemaToTS` returns `sanitizeIdentifier(refName)` on cycles, restoring the type:

```diff
- friends?: unknown[];
+ friends?: User[];
```

Trade-off: only works for refs into `components.schemas` (which the contracts file emits). Inline recursive schemas (rare anti-pattern) still produce `unknown` — acceptable.

## #32 — additionalProperties

Object schemas with `additionalProperties` previously dropped the clause silently. Now `schemaToTS` honors the contract:

| Input | Output |
|---|---|
| `additionalProperties: true` | `Record<string, unknown>` |
| `additionalProperties: { type: "string" }` | `Record<string, string>` |
| `additionalProperties: false` / missing | no Record clause (closed shape) |

Combined with named props, the open shape becomes an intersection:

```diff
- export type Get_dictionaryResponse200 = { id?: string; };
+ export type Get_dictionaryResponse200 = { id?: string; } & Record<string, string>;
```

Union/intersection value types in `additionalProperties` are wrapped in parens so `Record<string, A | B>` parses correctly.

## Tests
- Flipped `#26` and `#32` `it.fails()` markers to passing.
- Added two new `#32` tests for `true` and `false` variants (closed-shape regression check).
- Snapshot diff cleanly shows both fixes.

```
Test Files  4 passed (4)
     Tests  69 passed | 1 expected fail (70)
```

The single remaining expected-fail is `#31` follow-up (HEAD/OPTIONS/TRACE emission, requires runtime-client extension — separate PR).

## Test plan
- [ ] `npm test` passes (69 / 1 expected fail)
- [ ] `npm run build` clean
- [ ] Manual: a spec with a recursive type (e.g. tree, nested comments) → generated client compiles and `T.children: T[]` is correctly typed
- [ ] Manual: a spec with `additionalProperties: { type: "X" }` → generated type accepts arbitrary keys with that value type

🤖 Generated with [Claude Code](https://claude.com/claude-code)