### PR TITLE
fix(config,fetcher): validation hardening — SSRF, TOML escape, defaults, auto-create, env regex

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -98,13 +98,17 @@ export const DEFAULT_WATCH_CONFIG: WatchConfig = {
 
 /**
  * Default instance configuration values.
+ *
+ * `with_credentials` defaults to `false` — sending cookies cross-origin
+ * is a footgun for cookie-based auth setups and not what most users
+ * want. Cookie-auth users opt in explicitly. Issue #28.
  */
 export const DEFAULT_INSTANCE_CONFIG: InstanceConfig = {
   base_url_env: "API_BASE_URL",
   env_accessor: "process.env",
   token_key: "auth-token",
   auth_mode: "custom",
-  with_credentials: true,
+  with_credentials: false,
   timeout: 30_000,
 };
 
@@ -124,16 +128,32 @@ export const DEFAULT_CONFIG: ApiConfig = {
 };
 
 /**
+ * Encodes an arbitrary string for safe inclusion in a TOML basic string
+ * value. JSON.stringify produces a strict subset of TOML basic-string
+ * syntax (`\"`, `\\`, `\n`, `\t`, `\r`, `\uXXXX`), so any character a
+ * user types — including `"`, `\`, control codes, non-ASCII — round-
+ * trips through TOML safely. Issue #27.
+ */
+function tomlEscape(value: string): string {
+  return JSON.stringify(value);
+}
+
+/**
  * Generates config file content from an ApiConfig object.
  * Single source of truth — used by both auto-create and init command.
+ *
+ * Every interpolated string flows through `tomlEscape` (`JSON.stringify`)
+ * so values containing `"`, `\`, or control chars produce valid TOML
+ * rather than a malformed file. Issue #27.
  */
 export function generateConfigTemplate(config: ApiConfig): string {
   // Emit whichever spec source is configured as the active line, and the
   // other as a commented-out example.
+  const fallbackEndpoint = config.api_endpoint ?? "https://api.example.com/openapi.json";
   const specSourceBlock = config.spec_file
-    ? `# api_endpoint = "${config.api_endpoint ?? "https://api.example.com/openapi.json"}"  # Use remote endpoint instead of local file
-spec_file = "${config.spec_file}"`
-    : `api_endpoint = "${config.api_endpoint}"
+    ? `# api_endpoint = ${tomlEscape(fallbackEndpoint)}  # Use remote endpoint instead of local file
+spec_file = ${tomlEscape(config.spec_file)}`
+    : `api_endpoint = ${tomlEscape(config.api_endpoint ?? "")}
 # spec_file = "./openapi.json"  # Use local file instead of remote`;
 
   return `# Chowbea Axios Configuration
@@ -142,13 +162,13 @@ ${specSourceBlock}
 poll_interval_ms = ${config.poll_interval_ms}
 
 [output]
-folder = "${config.output.folder}"
+folder = ${tomlEscape(config.output.folder)}
 
 [instance]
-base_url_env = "${config.instance.base_url_env}"
-env_accessor = "${config.instance.env_accessor}"
-token_key = "${config.instance.token_key}"
-auth_mode = "${config.instance.auth_mode}"
+base_url_env = ${tomlEscape(config.instance.base_url_env)}
+env_accessor = ${tomlEscape(config.instance.env_accessor)}
+token_key = ${tomlEscape(config.instance.token_key)}
+auth_mode = ${tomlEscape(config.instance.auth_mode)}
 with_credentials = ${config.instance.with_credentials}
 timeout = ${config.instance.timeout}
 
@@ -501,10 +521,31 @@ export function resolveSpecSource(
 }
 
 /**
- * Loads and parses the configuration file.
- * Auto-creates with defaults if missing.
+ * Options for `loadConfig`.
  */
-export async function loadConfig(configPath?: string): Promise<{
+export interface LoadConfigOptions {
+  /**
+   * When true and the config file is missing, create one with defaults.
+   * Defaults to false — only `init` should create config; other commands
+   * fail loudly when config is absent so CI/non-interactive runs don't
+   * silently use a localhost endpoint. Issue #39.
+   */
+  autoCreate?: boolean;
+}
+
+/**
+ * Loads and parses the configuration file.
+ *
+ * By default, throws `ConfigError` when the file is missing — call sites
+ * that legitimately want to create one (only `init`) opt in via
+ * `{ autoCreate: true }`. This prevents commands like `fetch`/`generate`
+ * from silently writing a default config in CI environments where a
+ * missing file should be a hard error. Issue #39.
+ */
+export async function loadConfig(
+  configPath?: string,
+  options: LoadConfigOptions = {},
+): Promise<{
   config: ApiConfig;
   projectRoot: string;
   configPath: string;
@@ -518,7 +559,13 @@ export async function loadConfig(configPath?: string): Promise<{
   const exists = await configExists(resolvedConfigPath);
 
   if (!exists) {
-    // Auto-create config with defaults
+    if (!options.autoCreate) {
+      throw new ConfigError(
+        `No api.config.toml found at ${resolvedConfigPath}`,
+        "Run 'chowbea-axios init' to create one.",
+      );
+    }
+    // Auto-create config with defaults (init only)
     await createDefaultConfig(resolvedConfigPath);
 
     return {

--- a/src/core/fetcher.ts
+++ b/src/core/fetcher.ts
@@ -119,20 +119,30 @@ const DEFAULT_RETRY_CONFIG: RetryConfig = {
 
 /**
  * Interpolates environment variables in a string.
- * Replaces $VAR_NAME or ${VAR_NAME} with the environment variable value.
+ *
+ * Recognizes both `$VAR_NAME` and `${VAR_NAME}` forms. Mismatched braces
+ * (`${VAR` or `$VAR}`) no longer match — the prior regex used independent
+ * `?`-quantified braces and silently consumed half-pairs. Issue #29.
+ *
  * Throws if a referenced env var is not set.
  */
 export function interpolateEnvVars(value: string): string {
-	// Match $VAR_NAME or ${VAR_NAME}
-	return value.replace(/\$\{?([A-Z_][A-Z0-9_]*)\}?/gi, (_match, varName) => {
-		const envValue = process.env[varName];
-		if (envValue === undefined) {
-			throw new Error(
-				`Environment variable ${varName} is not set (referenced in: ${value})`
-			);
-		}
-		return envValue;
-	});
+	// Match either `${VAR}` (braced) or `$VAR` (bare). Two alternatives
+	// rather than independent optional braces ensures we never consume a
+	// stray `{` or `}`.
+	return value.replace(
+		/\$\{([A-Z_][A-Z0-9_]*)\}|\$([A-Z_][A-Z0-9_]*)/gi,
+		(_match, braced: string | undefined, bare: string | undefined) => {
+			const varName = braced ?? bare ?? "";
+			const envValue = process.env[varName];
+			if (envValue === undefined) {
+				throw new Error(
+					`Environment variable ${varName} is not set (referenced in: ${value})`
+				);
+			}
+			return envValue;
+		},
+	);
 }
 
 /**
@@ -213,6 +223,36 @@ export async function loadCachedSpec(specPath: string): Promise<Buffer | null> {
 }
 
 /**
+ * Validates a remote endpoint URL before we issue an HTTP request to it.
+ *
+ * - Must parse as a URL (rejects garbage strings).
+ * - Must use `http:` or `https:` (rejects `file:`, `data:`, custom
+ *   schemes that could exfiltrate or sidestep the fetch pipeline).
+ *
+ * Issue #20. Tightening to also reject private/loopback hosts is a
+ * separate optional layer — left to a future opt-in flag because most
+ * legitimate users develop against `localhost:3000`.
+ */
+function validateEndpointUrl(endpoint: string): URL {
+	let url: URL;
+	try {
+		url = new URL(endpoint);
+	} catch {
+		throw new NetworkError(
+			endpoint,
+			`Invalid endpoint URL: ${endpoint}`,
+		);
+	}
+	if (url.protocol !== "http:" && url.protocol !== "https:") {
+		throw new NetworkError(
+			endpoint,
+			`Unsupported URL scheme "${url.protocol}" — only http: and https: are allowed for remote spec endpoints.`,
+		);
+	}
+	return url;
+}
+
+/**
  * Fetches the OpenAPI spec from a remote endpoint with retry logic.
  * Falls back to cached spec on network failure.
  */
@@ -228,6 +268,10 @@ export async function fetchOpenApiSpec(options: {
 }): Promise<FetchResult> {
 	const { endpoint, specPath, cachePath, logger, force = false } = options;
 	const retryConfig = options.retryConfig ?? DEFAULT_RETRY_CONFIG;
+
+	// Reject malformed or non-http(s) URLs before issuing any network
+	// request. Issue #20.
+	validateEndpointUrl(endpoint);
 
 	// Interpolate env vars in headers
 	const headers: Record<string, string> = {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,123 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import toml from "toml";
+import { describe, expect, it } from "vitest";
+
+import {
+	DEFAULT_CONFIG,
+	DEFAULT_INSTANCE_CONFIG,
+	generateConfigTemplate,
+	loadConfig,
+} from "../src/core/config.js";
+
+describe("DEFAULT_INSTANCE_CONFIG (#28)", () => {
+	it("with_credentials defaults to false (cookies are opt-in)", () => {
+		expect(DEFAULT_INSTANCE_CONFIG.with_credentials).toBe(false);
+	});
+});
+
+describe("generateConfigTemplate (#27 — TOML escaping)", () => {
+	it("round-trips quotes, backslashes, and control chars in string fields", () => {
+		const config = {
+			...DEFAULT_CONFIG,
+			api_endpoint: 'https://api.example.com/path?q="hello"&x=\\\\',
+			output: { folder: 'src/api with "quotes"' },
+			instance: {
+				...DEFAULT_INSTANCE_CONFIG,
+				token_key: 'tok"en\\back',
+				base_url_env: "API_BASE_URL",
+				env_accessor: "process.env",
+			},
+		};
+		const tomlText = generateConfigTemplate(config);
+		// The output must parse cleanly (i.e. the special chars are escaped).
+		const parsed = toml.parse(tomlText) as Record<string, unknown>;
+		expect(parsed.api_endpoint).toBe(config.api_endpoint);
+		expect((parsed.output as Record<string, unknown>).folder).toBe(
+			config.output.folder,
+		);
+		const inst = parsed.instance as Record<string, unknown>;
+		expect(inst.token_key).toBe(config.instance.token_key);
+	});
+
+	it("never produces broken TOML even when token_key contains injection-style payloads", () => {
+		const config = {
+			...DEFAULT_CONFIG,
+			instance: {
+				...DEFAULT_INSTANCE_CONFIG,
+				token_key: 'foo"\nmalicious_key = "x',
+			},
+		};
+		const tomlText = generateConfigTemplate(config);
+		// Parse must succeed.
+		const parsed = toml.parse(tomlText);
+		// And the malicious "second key" payload must NOT have created a
+		// new top-level entry — the literal string is preserved, not split.
+		expect(
+			(parsed as { malicious_key?: unknown }).malicious_key,
+		).toBeUndefined();
+		const inst = (parsed as { instance: Record<string, unknown> }).instance;
+		expect(inst.token_key).toBe('foo"\nmalicious_key = "x');
+	});
+});
+
+describe("loadConfig (#39 — no auto-create without opt-in)", () => {
+	async function withTempProject<T>(
+		fn: (root: string, configPath: string) => Promise<T>,
+	): Promise<T> {
+		const root = join(
+			tmpdir(),
+			`chowbea-loadconfig-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		await mkdir(root, { recursive: true });
+		await writeFile(
+			join(root, "package.json"),
+			JSON.stringify({ name: "test", version: "0.0.0" }),
+			"utf8",
+		);
+		const configPath = join(root, "api.config.toml");
+		try {
+			return await fn(root, configPath);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	}
+
+	it("throws ConfigError when the file is missing and autoCreate is not set", async () => {
+		await withTempProject(async (_root, configPath) => {
+			await expect(loadConfig(configPath)).rejects.toThrow(
+				/No api\.config\.toml found/,
+			);
+		});
+	});
+
+	it("error message points the user at `chowbea-axios init`", async () => {
+		await withTempProject(async (_root, configPath) => {
+			try {
+				await loadConfig(configPath);
+				expect.unreachable();
+			} catch (err) {
+				const msg = err instanceof Error ? err.message : String(err);
+				expect(msg).toMatch(/No api\.config\.toml/);
+				// `recoveryHint` is on the ChowbeaAxiosError instance.
+				const hint = (err as { recoveryHint?: string }).recoveryHint;
+				expect(hint).toMatch(/chowbea-axios init/);
+			}
+		});
+	});
+
+	it("creates the config when autoCreate is explicitly true (init's path)", async () => {
+		await withTempProject(async (_root, configPath) => {
+			const result = await loadConfig(configPath, { autoCreate: true });
+			expect(result.wasCreated).toBe(true);
+			// The returned config matches DEFAULT_CONFIG.
+			expect(result.config.poll_interval_ms).toBe(
+				DEFAULT_CONFIG.poll_interval_ms,
+			);
+			// And the file exists on disk now.
+			const re = await loadConfig(configPath);
+			expect(re.wasCreated).toBe(false);
+		});
+	});
+});

--- a/tests/fetcher-validation.test.ts
+++ b/tests/fetcher-validation.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import { interpolateEnvVars } from "../src/core/fetcher.js";
+
+describe("interpolateEnvVars (#29 — mismatched-brace regex)", () => {
+	it("substitutes ${VAR} (braced)", () => {
+		process.env.CHOWBEA_TEST_VAR = "from-env";
+		try {
+			expect(interpolateEnvVars("a ${CHOWBEA_TEST_VAR} b")).toBe(
+				"a from-env b",
+			);
+		} finally {
+			delete process.env.CHOWBEA_TEST_VAR;
+		}
+	});
+
+	it("substitutes $VAR (bare)", () => {
+		process.env.CHOWBEA_TEST_VAR = "from-env";
+		try {
+			expect(interpolateEnvVars("a $CHOWBEA_TEST_VAR b")).toBe("a from-env b");
+		} finally {
+			delete process.env.CHOWBEA_TEST_VAR;
+		}
+	});
+
+	it("does NOT consume a stray `}` after a bare `$VAR` (mismatched close)", () => {
+		process.env.CHOWBEA_TEST_VAR = "x";
+		try {
+			// `$VAR}` must produce `x}` — the `}` is preserved as literal text,
+			// not silently swallowed by the regex.
+			expect(interpolateEnvVars("a $CHOWBEA_TEST_VAR} b")).toBe("a x} b");
+		} finally {
+			delete process.env.CHOWBEA_TEST_VAR;
+		}
+	});
+
+	it("does NOT consume a stray `${` (mismatched open)", () => {
+		process.env.CHOWBEA_TEST_VAR = "x";
+		try {
+			// `${VAR` (no closing brace) must NOT match the braced form. The
+			// `${` is left as literal text and the bare `$VAR` form does not
+			// match either (the leading `{` blocks it). Result is the input.
+			expect(interpolateEnvVars("a ${CHOWBEA_TEST_VAR b")).toBe(
+				"a ${CHOWBEA_TEST_VAR b",
+			);
+		} finally {
+			delete process.env.CHOWBEA_TEST_VAR;
+		}
+	});
+
+	it("throws when the referenced variable is unset", () => {
+		delete process.env.CHOWBEA_NEVER_SET;
+		expect(() => interpolateEnvVars("${CHOWBEA_NEVER_SET}")).toThrow(
+			/CHOWBEA_NEVER_SET/,
+		);
+	});
+
+	it("handles mixed braced and bare forms in one string", () => {
+		process.env.CHOWBEA_A = "alpha";
+		process.env.CHOWBEA_B = "beta";
+		try {
+			expect(interpolateEnvVars("$CHOWBEA_A and ${CHOWBEA_B}!")).toBe(
+				"alpha and beta!",
+			);
+		} finally {
+			delete process.env.CHOWBEA_A;
+			delete process.env.CHOWBEA_B;
+		}
+	});
+});
+
+describe("fetchOpenApiSpec URL validation (#20 — SSRF / scheme allowlist)", () => {
+	// We're not actually hitting the network here — validation runs before
+	// any fetch attempt, so the function should reject synchronously for
+	// invalid URLs.
+	const baseOpts = (endpoint: string) => ({
+		endpoint,
+		specPath: "/tmp/never-used",
+		cachePath: "/tmp/never-used",
+		logger: {
+			level: "silent" as const,
+			header: () => {},
+			step: () => {},
+			info: (() => {}) as never,
+			warn: (() => {}) as never,
+			error: (() => {}) as never,
+			debug: (() => {}) as never,
+			done: () => {},
+			startProgress: () => {},
+			stopProgress: () => {},
+		},
+	});
+
+	it("rejects file: URLs", async () => {
+		const { fetchOpenApiSpec } = await import("../src/core/fetcher.js");
+		await expect(fetchOpenApiSpec(baseOpts("file:///etc/passwd"))).rejects.toThrow(
+			/Unsupported URL scheme/,
+		);
+	});
+
+	it("rejects custom-scheme URLs", async () => {
+		const { fetchOpenApiSpec } = await import("../src/core/fetcher.js");
+		await expect(fetchOpenApiSpec(baseOpts("ftp://example.com/spec.json"))).rejects.toThrow(
+			/Unsupported URL scheme/,
+		);
+	});
+
+	it("rejects garbage strings", async () => {
+		const { fetchOpenApiSpec } = await import("../src/core/fetcher.js");
+		await expect(fetchOpenApiSpec(baseOpts("not a url at all"))).rejects.toThrow(
+			/Invalid endpoint URL/,
+		);
+	});
+
+	it("accepts http: scheme (validation passes; fetch will fail at network)", async () => {
+		const { fetchOpenApiSpec } = await import("../src/core/fetcher.js");
+		// Validation should NOT throw a "scheme" error — the eventual error
+		// will be a NetworkError from the unreachable host, after retries.
+		// We just verify the rejection isn't a scheme rejection.
+		await expect(
+			fetchOpenApiSpec({
+				...baseOpts("http://127.0.0.1:1/never-here"),
+				retryConfig: { maxAttempts: 1, baseDelay: 1, backoffMultiplier: 1 },
+			}),
+		).rejects.toThrow();
+		// (No assertion on the exact message — any error other than
+		// "Unsupported URL scheme" / "Invalid endpoint URL" passes the
+		// scheme/format check.)
+	});
+});

--- a/tests/generator.test.snap
+++ b/tests/generator.test.snap
@@ -946,7 +946,7 @@ import axios from "axios";
  */
 export const axiosInstance = axios.create({
 	baseURL: process.env.API_BASE_URL,
-	withCredentials: true,
+	withCredentials: false,
 	timeout: 30000,
 });
 


### PR DESCRIPTION
## Summary
Five tightly related input-validation gaps in `config.ts` and `fetcher.ts`. Each is small but they share the same theme and test surface so they ship together.

Closes #20 · Closes #27 · Closes #28 · Closes #29 · Closes #39

## Changes

### #20 — SSRF / scheme allowlist
`fetchOpenApiSpec` now calls `validateEndpointUrl` before issuing any HTTP request. The URL must parse and use `http:`/`https:`. Rejects `file:`, `ftp:`, `data:`, custom schemes, and garbage strings. Private-host blocking is left to a future opt-in flag because most legitimate users develop against `localhost:3000`.

### #27 — TOML interpolation escaping
`generateConfigTemplate` interpolates every string field via a new `tomlEscape(value)` helper backed by `JSON.stringify`. Special chars (`"`, `\`, control codes, non-ASCII) round-trip cleanly. Adversarial payloads like `token_key = 'foo"\nmalicious_key = "x'` no longer create stray top-level entries in the emitted file.

### #28 — `with_credentials` default
`DEFAULT_INSTANCE_CONFIG.with_credentials` flips `true → false`. Cookie-auth users opt in explicitly via `api.config.toml`. Existing projects with a generated `api.instance.ts` keep their old value until they regenerate (the file is "generate-once").

### #29 — `interpolateEnvVars` mismatched braces
The old regex `/\$\{?(VAR)\}?/` matched both `${VAR}` and `$VAR}` (silently consuming the stray `}`). Replaced with two explicit alternatives — `\$\{(...)\}|\$(...)` — so mismatched braces stay literal text.

### #39 — no auto-create config
`loadConfig` now accepts `{ autoCreate?: boolean }`. Default is `false` — missing config throws `ConfigError` pointing at `chowbea-axios init`. Previously every command silently wrote a default config with `localhost:3000`, masking real misconfiguration in CI.

## Tests
- **`tests/config.test.ts`** (6 tests) — `with_credentials` default, TOML escape round-trip + injection-resistance, `loadConfig` throw/recovery/opt-in
- **`tests/fetcher-validation.test.ts`** (10 tests) — `interpolateEnvVars` regex variants + `fetchOpenApiSpec` URL validation
- Snapshot refreshed (`api.instance.ts` now emits `withCredentials: false`)

```
Test Files  6 passed (6)
     Tests  85 passed | 1 expected fail (86)
```

## Verification
- `npm test` ✓
- `npm run build` ✓
- Smoke (`.context/smoke-test/petstore.yaml`) → fetch + tsc → exit 0
- Smoke (no-config dir) → `status` errors cleanly with `"No api.config.toml found … Run 'chowbea-axios init' to create one"`

## Test plan
- [ ] `npm test` passes (85 / 1 expected fail)
- [ ] `npm run build` clean
- [ ] Manual: spec endpoint with `file://` scheme is rejected
- [ ] Manual: `chowbea-axios fetch` in a fresh repo errors instead of auto-creating
- [ ] Manual: `chowbea-axios init` still creates config
- [ ] Manual: `api.config.toml` with `token_key = 'with"quote'` parses round-trip via init wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)