### PR TITLE
Add CHANGELOG.md with per-version history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,94 @@
+# Changelog
+
+All notable changes to `chowbea-axios` will be documented in this file.
+
+The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). While the `2.0.0-alpha.*` line is active, breaking changes may land between alpha versions — see [SECURITY.md](SECURITY.md) for the supported-versions policy.
+
+## [Unreleased]
+
+_Nothing yet._
+
+## [2.0.0-alpha.22] — 2026-05-15
+
+The largest alpha shipped to date. Bundles the full "package review" hardening pass (PRs #55–#60) with the first round of enterprise-adoption-readiness fixes from a fresh internal audit ([docs/reviews/2026-05-04-adoption-readiness.md](docs/reviews/2026-05-04-adoption-readiness.md)). No breaking changes for adopters of `alpha.21`.
+
+### Added
+
+- New `release:experimental` npm script that does `npm ci → npm version prerelease → npm publish --tag experimental → git push --follow-tags` as one atomic operation. Replaces the brittle bare-`npm publish` flow that fails on fresh checkouts (`tsc: command not found`).
+- `SECURITY.md` with a private vulnerability-disclosure policy (GitHub security advisory + `platforms@chowbea.com`), 7-day acknowledgement target, supported-versions statement, and scope definition.
+- `LICENSE` and `SECURITY.md` explicitly whitelisted in `package.json#files` so they ship in every npm tarball (npm only includes `LICENSE` and `README` implicitly).
+- `docs/reviews/2026-05-04-adoption-readiness.md` — full adoption-readiness audit covering security, code quality, and docs/legal/ops lanes. Living index linking each deferred finding to its GitHub issue (#61–#72).
+- Emitted operation functions now include an `@remarks` JSDoc line documenting that path parameter values are URL-encoded by the underlying HTTP layer, removing an implicit safety guarantee that adopters previously had to discover.
+- Vitest snapshot suite covering generator emission for petstore + edge-case OpenAPI fixtures (#48).
+- Hardened CI template shipped to users under `templates/chowbea-axios-ci.yml`: default-deny permissions, concurrency cancel, scoped diff paths, pinned action SHAs.
+
+### Changed
+
+- `createOperations` in the emitted `api.operations.ts` template no longer takes `apiClient: any`. The parameter is now typed as a documented structural `ApiClient` interface. Adopters reading the generated code see a real type contract on the most-called API instead of a silent `any` escape hatch.
+- TOML and YAML config values are now round-tripped via `JSON.stringify`-based escaping, removing a class of injection bugs where a stray `"` or `\n` in a config value could create stray top-level entries.
+- Spec fetcher now validates URLs against an allowlist of schemes (`http:`/`https:`) before dispatching, rejecting `file:`, `ftp:`, and custom-scheme SSRF vectors (#56).
+- Backup-and-restore semantics around the generator's destination tree are now atomic (temp-then-rename) for `api.types.ts`, `api.operations.ts`, and `api.contracts.ts`.
+
+### Fixed
+
+- Watch mode no longer thunders on rapid file changes; debounce + exponential backoff added (#57).
+- Process manager no longer leaks orphaned child processes when the TUI exits abnormally (#57).
+- Instance config drift between TUI state and disk is now reconciled on every save (#57).
+- Cross-platform path handling on Windows: backslash normalization, drive-letter case, UNC paths (#57).
+- Router fallback when an unknown screen ID is requested (#57).
+- Env manager regex no longer consumes half-matched braces; `$VAR` and `${VAR}` are now distinct alternatives (#59).
+- Deep-diff comparison no longer reports false positives on object key reordering (#59).
+- Hex-color env values (`#abcdef`) are correctly preserved through the env round-trip (#59).
+- Non-interactive `init` flow correctly honors `--non-interactive` for project-starter use cases (#59).
+- `bun.lock` is now detected alongside `package-lock.json` for package-manager inference (#58).
+
+### Security
+
+- Spec fetcher URL allowlist (above) — closes SSRF vector for malicious or misconfigured OpenAPI endpoint URLs (#56).
+- TOML/YAML config-value escaping (above) — prevents injection of stray top-level config entries via crafted string values (#56).
+- `npm audit` cleaned to 0 vulnerabilities; dependency ranges pinned with `^`/`~` (no `*` or `latest`) (#58).
+
+## [2.0.0-alpha.21] — 2026-04-23
+
+Combined fixes from `fix/operation-types` and `fix/dotted-property-keys` released for end-to-end alpha validation.
+
+### Fixed
+
+- Emitted operation functions now reference named contract types from `api.contracts.ts` instead of doing path-keyed lookups against `api.types.ts`. Cmd-click in adopters' editors now jumps to the real interface declaration (#6).
+- 2xx responses declared with `*/*` or JSON-variant media types (`application/vnd.api+json` etc.) now type correctly instead of falling back to `unknown` (#4728c18).
+- Property keys that aren't valid TypeScript identifiers (`hub.mode`, `X-Custom-Header`, `0.5`) are now quoted in emitted object literals so the generated TypeScript remains syntactically valid (#cef33ef).
+- `spec_file`-only configs (with no `endpoint`) are now supported across `validator`, `generate`, `watch`, `diff`, and `init` so adopters with local-only spec workflows aren't forced to declare a fake endpoint (#9).
+- CLI progress is now visible by default; watch-mode heartbeats prevent the appearance of a stalled CLI on long-running specs (#10).
+
+## [2.0.0-alpha.20] — 2026-04-21
+
+Adds Basic Auth for Swagger spec endpoints and a substantial codegen-correctness pass for adopters with complex schemas.
+
+### Added
+
+- Basic Auth support for Swagger spec endpoints — useful for internal/staging environments that don't expose anonymous spec access (#5).
+- Smart validation pass before generation, catching common spec errors with actionable messages (#3).
+- `$ref` utilities — the generator now walks reference chains for `components/parameters`, `components/requestBodies`, and `components/responses`, not just `components/schemas` (#3).
+- Vite codegen plugins (`surfacesCodegen`, `sidepanelsCodegen`) for adopters using Vite as their build tool (#3).
+- Windows path compatibility — generator now handles backslash-separated paths, drive letters, and UNC paths on Windows hosts (#3).
+
+### Fixed
+
+- CLI progress visibility default (#f2631b3).
+
+## [2.0.0-alpha.10] — 2026-03-25 (and earlier)
+
+The pre-`alpha.20` history covers the project's initial scaffolding, OpenTUI conversion, and rapid early iteration. Notable milestones:
+
+- **`alpha.10`** (2026-03-25): security, cross-platform, correctness, and quality fixes addressing CodeRabbit PR review findings.
+- **`alpha.10`** also introduced the env manager, the process-runner redesign, and the first round of UI polish (#d4fa02b).
+- **`alpha.5`** (2026-03-24): initial TUI conversion from the OCLIF CLI to an OpenTUI dashboard with endpoint inspector (#2).
+- **`alpha.2`–`alpha.4`** (2026-03-24): initial publishes.
+
+For full pre-`alpha.20` history, see `git log v2.0.0-alpha.2..v2.0.0-alpha.10`.
+
+[Unreleased]: https://github.com/oddFEELING/chowbea-axios/compare/v2.0.0-alpha.22...HEAD
+[2.0.0-alpha.22]: https://github.com/oddFEELING/chowbea-axios/compare/v2.0.0-alpha.21...v2.0.0-alpha.22
+[2.0.0-alpha.21]: https://github.com/oddFEELING/chowbea-axios/compare/v2.0.0-alpha.20...v2.0.0-alpha.21
+[2.0.0-alpha.20]: https://github.com/oddFEELING/chowbea-axios/compare/v2.0.0-alpha.10...v2.0.0-alpha.20
+[2.0.0-alpha.10]: https://github.com/oddFEELING/chowbea-axios/releases/tag/v2.0.0-alpha.10

--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ If chowbea-axios helps you ship faster, consider giving it a star! It helps othe
   </a>
 </p>
 
+## Changelog
+
+Release history and per-version changes live in [CHANGELOG.md](CHANGELOG.md).
+
 ## Security
 
 Found a security issue? Please follow our [responsible disclosure policy](SECURITY.md) — do **not** file a public GitHub issue.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "dist",
     "templates",
     "LICENSE",
-    "SECURITY.md"
+    "SECURITY.md",
+    "CHANGELOG.md"
   ],
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary

Closes #62 (H4 from the [2026-05-04 adoption-readiness audit](https://github.com/oddFEELING/chowbea-axios/blob/main/docs/reviews/2026-05-04-adoption-readiness.md)).

Adds `CHANGELOG.md` in [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format with retroactive per-version entries for the last three published alphas (`alpha.20`, `alpha.21`, `alpha.22`) and a combined summary for everything before that. Earlier alphas weren't tagged consistently in git, so per-version archaeology gets diminishing returns — the combined entry points readers at `git log` for the full pre-`alpha.20` history.

Going forward, the changelog gets updated manually as part of each release. Automating it via `release-please` (or similar) is deferred until CI lands (#61) so the release workflow can drive both at once.

### Per-version coverage

- **`2.0.0-alpha.22` (2026-05-15)** — full audit-fix bundle + the entire package-review hardening pass (PRs #55–#60) that was sitting unpublished between `alpha.21` and `alpha.22`. Added / Changed / Fixed / Security sections.
- **`2.0.0-alpha.21` (2026-04-23)** — combined generator fixes: named-contract references, `*/*` and json-variant media types, dotted property key quoting, `spec_file`-only configs, CLI progress visibility.
- **`2.0.0-alpha.20` (2026-04-21)** — Basic Auth for spec endpoints, `$ref` utilities for parameters / requestBodies / responses, Vite codegen plugins, Windows path compatibility.
- **`alpha.10` and earlier** — combined entry summarizing the OpenTUI conversion and initial scaffolding, with a pointer to `git log` for full archaeology.

### Side changes

- `CHANGELOG.md` added to `package.json#files` so it ships in the npm tarball (npm doesn't include it by default — same reasoning that justified explicit `LICENSE` and `SECURITY.md` whitelisting in PR #73).
- README gets a `## Changelog` section linking to the file.

## Test plan

- [x] `npm publish --tag experimental --dry-run` — verified `CHANGELOG.md` appears in the tarball alongside `LICENSE`, `README.md`, `SECURITY.md`.
- [x] Markdown lints cleanly (manual eyeball).
- [x] Compare links at the bottom of CHANGELOG.md point at real tags.
- [ ] You decide whether the `alpha.20`/`alpha.21` entries capture enough — easy to expand if a deeper retroactive pass is wanted. The current coverage is the "Option A" scope we agreed on (recent versions detailed, earlier summarized).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive changelog with detailed release history, documenting new features, bug fixes, and security updates across multiple product versions
  * Added Changelog section to README to provide users quick access to release notes and version-specific information

* **Chores**
  * Updated package manifest to ensure changelog and security documentation files are properly included in published package releases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oddFEELING/chowbea-axios/pull/74)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->