### PR TITLE
Add CI workflows + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+# Dependabot config — weekly dep + action updates.
+#
+# Two ecosystems:
+#   1. npm — application dependencies in package.json
+#   2. github-actions — workflow YAML in .github/workflows/
+#
+# Updates are grouped per ecosystem so we don't get a flood of single-dep
+# PRs every week. Major-version bumps still come as individual PRs so they
+# can be reviewed in isolation.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      # Group all minor + patch bumps into one PR per ecosystem to reduce noise.
+      # Majors stay separate (they're more likely to break and deserve a focused
+      # review).
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    # Ignore axios major bumps for now — it's an exported peer-shape concern
+    # and a breaking change there ripples into adopter code. Reconsider if/when
+    # we add a runtime-behavior test that exercises axios edge cases.
+    ignore:
+      - dependency-name: axios
+        update-types: [version-update:semver-major]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - tooling
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,125 @@
+# Continuous integration for chowbea-axios itself.
+#
+# What runs:
+#   - On every PR and every push to `main`
+#   - Matrix: 3 operating systems (ubuntu/macos/windows) × 3 Node majors (20/22/24)
+#   - Per job: install → build (tsc) → test (vitest)
+#
+# Why a 9-cell matrix:
+#   - The generator does cross-platform path handling (see Windows path fixes
+#     in alpha.20 / commit e8213fc). Without Windows in CI those regress silently.
+#   - Adopters run on whatever LTS they have. Engines declare `>=20`, so 20/22/24
+#     all need to pass.
+#
+# Third-party actions are pinned to commit SHAs (not version tags) — a tag can
+# be re-pointed at malicious code, a commit SHA cannot. Bump these via
+# Dependabot (see .github/dependabot.yml).
+name: ci
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+# Cancel in-flight runs on the same ref when a new commit arrives.
+# Saves minutes and avoids stale CI signal on rapid pushes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Default-deny: only contents:read for checking out the repo.
+# No write scopes needed — this workflow only reports status.
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test (${{ matrix.os }} / Node ${{ matrix.node }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      # One failure shouldn't cancel the rest of the matrix — we want to see
+      # which OS/Node combinations break, not just the first.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: ["20", "22", "24"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js ${{ matrix.node }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.node }}
+          # Built-in npm cache keyed on package-lock.json. Drastically reduces
+          # cold-install time for the matrix.
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build (tsc)
+        run: npm run build
+
+      - name: Test (vitest)
+        run: npm test
+
+  pack-check:
+    # Verifies the published tarball contains the files we expect and excludes
+    # the ones we don't (src/, tests/, docs/, .planning/). Catches regressions
+    # in package.json#files whitelist before a release ships.
+    name: pack-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Pack and list tarball contents
+        run: |
+          npm pack --dry-run --json > pack.json
+          echo "=== Files that will ship ==="
+          node -e "const p=require('./pack.json');p[0].files.map(f=>f.path).sort().forEach(f=>console.log(f))"
+
+      - name: Assert LICENSE, SECURITY.md, README.md present in tarball
+        run: |
+          node <<'NODE'
+          const required = ['LICENSE', 'SECURITY.md', 'README.md', 'package.json'];
+          const pack = require('./pack.json')[0];
+          const files = new Set(pack.files.map(f => f.path));
+          const missing = required.filter(f => !files.has(f));
+          if (missing.length > 0) {
+            console.error('Tarball missing required files:', missing.join(', '));
+            process.exit(1);
+          }
+          console.log('All required files present in tarball.');
+          NODE
+
+      - name: Assert no source/test/planning files leaked into tarball
+        run: |
+          node <<'NODE'
+          const pack = require('./pack.json')[0];
+          const banned = pack.files
+            .map(f => f.path)
+            .filter(p => /^(src|tests|docs|\.planning)\//.test(p));
+          if (banned.length > 0) {
+            console.error('Tarball contains files that should be excluded:');
+            banned.forEach(p => console.error('  ' + p));
+            process.exit(1);
+          }
+          console.log('No source/test/planning files leaked into tarball.');
+          NODE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,41 @@
 # Release workflow — publishes to npm with provenance on tag push.
 #
-# Trigger: push of a `v*` tag (created by `npm run release:experimental`).
+# Trigger: push of a `v*` tag (created by `npm run release:experimental`
+# locally, or pushed by hand).
 # Effect: builds, tests, then `npm publish --provenance --tag experimental`.
 #
-# REQUIRED SECRETS / SETUP (one-time):
-#   1. On npmjs.com → Account → Access Tokens → Generate New Token →
-#      type **Automation** (this token bypasses 2FA, which is necessary
-#      for CI publishes — never use a Publish-type token with 2FA in CI).
-#   2. GitHub repo → Settings → Secrets and variables → Actions →
-#      New repository secret → Name: NPM_TOKEN → Value: (the token).
-#   3. Confirm "Allow GitHub Actions to publish with provenance" is on
-#      for the package on npmjs.com (default for new packages).
+# REQUIRED SETUP (one-time, on npmjs.com — NO GitHub secret needed):
+#   1. Sign in to npmjs.com and go to the chowbea-axios package settings:
+#        https://www.npmjs.com/package/chowbea-axios/access
+#   2. Find the "Trusted Publisher" section → Add publisher.
+#   3. Fill in:
+#        Publisher:           GitHub Actions
+#        Organization or user: oddFEELING
+#        Repository:          chowbea-axios
+#        Workflow filename:   release.yml
+#        Environment name:    (leave blank — we don't use GitHub Environments)
+#   4. Save.
 #
-# How provenance works:
-#   - The OIDC token (`id-token: write`) lets npm verify the publish came
-#     from this workflow, this commit, this repo. Adopters can check via
-#     `npm view chowbea-axios provenance` after install.
-#   - No code signing keys to manage — GitHub's OIDC + Sigstore handle it.
+# That's the entire setup. No NPM_TOKEN secret in this repo, no long-lived
+# access tokens to rotate. The OIDC token GitHub mints for this workflow
+# proves the publish came from this repo + this workflow file; npm verifies
+# it against the Trusted Publisher config and authorizes the publish.
+#
+# Adopters can verify provenance after install via:
+#   npm view chowbea-axios provenance
+#
+# Why Trusted Publishing instead of the older "Automation token" approach:
+#   - No long-lived secret to leak or rotate
+#   - npm's UI now actively warns against the "Bypass 2FA" token type
+#   - OIDC scopes the trust to *this* workflow file, not the whole account
 #
 # Manual fallback (if this workflow is broken):
 #   Use the local `npm run release:experimental` script. That path stays
 #   working — it just won't have provenance attestation.
+#
+# Requirements (provided by GitHub-hosted runner + actions/setup-node@v6):
+#   - npm CLI >= 11.5.1
+#   - Node >= 22.14.0
 name: release
 
 on:
@@ -30,7 +45,7 @@ on:
 
 # Default-deny except where required.
 #   contents: read   — checkout
-#   id-token: write  — OIDC token for npm provenance attestation
+#   id-token: write  — OIDC token for Trusted Publishing + provenance
 permissions:
   contents: read
   id-token: write
@@ -41,7 +56,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Defense-in-depth: only run for tags pushed to the canonical repo,
-    # not forks or accidental tag mirrors.
+    # not forks or accidental tag mirrors. (Trusted Publisher config on
+    # npmjs is already scoped to this repo, but the extra guard avoids
+    # spending CI minutes on doomed publishes from forks.)
     if: github.repository == 'oddFEELING/chowbea-axios'
     steps:
       - name: Checkout
@@ -52,8 +69,9 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-          # Points npm at the public registry and sets up the auth token.
-          # The token lives in NPM_TOKEN, exposed below as NODE_AUTH_TOKEN.
+          # registry-url is still required for Trusted Publishing — it
+          # tells npm where to send the publish + OIDC token. We just
+          # don't set NODE_AUTH_TOKEN; OIDC handles auth.
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
@@ -81,7 +99,7 @@ jobs:
           fi
           echo "Version matches tag: $PKG_VERSION"
 
-      - name: Publish to npm (with provenance)
+      - name: Publish to npm (with provenance via Trusted Publishing)
+        # No NODE_AUTH_TOKEN: OIDC token from `id-token: write` permission
+        # is exchanged for a scoped npm credential at publish time.
         run: npm publish --provenance --tag experimental
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+# Release workflow — publishes to npm with provenance on tag push.
+#
+# Trigger: push of a `v*` tag (created by `npm run release:experimental`).
+# Effect: builds, tests, then `npm publish --provenance --tag experimental`.
+#
+# REQUIRED SECRETS / SETUP (one-time):
+#   1. On npmjs.com → Account → Access Tokens → Generate New Token →
+#      type **Automation** (this token bypasses 2FA, which is necessary
+#      for CI publishes — never use a Publish-type token with 2FA in CI).
+#   2. GitHub repo → Settings → Secrets and variables → Actions →
+#      New repository secret → Name: NPM_TOKEN → Value: (the token).
+#   3. Confirm "Allow GitHub Actions to publish with provenance" is on
+#      for the package on npmjs.com (default for new packages).
+#
+# How provenance works:
+#   - The OIDC token (`id-token: write`) lets npm verify the publish came
+#     from this workflow, this commit, this repo. Adopters can check via
+#     `npm view chowbea-axios provenance` after install.
+#   - No code signing keys to manage — GitHub's OIDC + Sigstore handle it.
+#
+# Manual fallback (if this workflow is broken):
+#   Use the local `npm run release:experimental` script. That path stays
+#   working — it just won't have provenance attestation.
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+# Default-deny except where required.
+#   contents: read   — checkout
+#   id-token: write  — OIDC token for npm provenance attestation
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Defense-in-depth: only run for tags pushed to the canonical repo,
+    # not forks or accidental tag mirrors.
+    if: github.repository == 'oddFEELING/chowbea-axios'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: npm
+          # Points npm at the public registry and sets up the auth token.
+          # The token lives in NPM_TOKEN, exposed below as NODE_AUTH_TOKEN.
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        # Re-running tests on the exact published commit is the last
+        # safety net before a tarball ships. If this fails, the tag is
+        # bad and should be deleted.
+        run: npm test
+
+      - name: Verify package.json version matches tag
+        # Catches the case where the tag was pushed without a matching
+        # version bump in package.json — would silently re-publish the
+        # previous version under a new tag.
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION=${GITHUB_REF_NAME#v}
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "Version mismatch: package.json=$PKG_VERSION tag=$TAG_VERSION"
+            exit 1
+          fi
+          echo "Version matches tag: $PKG_VERSION"
+
+      - name: Publish to npm (with provenance)
+        run: npm publish --provenance --tag experimental
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/oddFEELING/chowbea-axios/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/oddFEELING/chowbea-axios/ci.yml?branch=main&style=flat-square&color=10b981" alt="CI" /></a>
   <a href="https://github.com/oddFEELING/chowbea-axios/stargazers"><img src="https://img.shields.io/github/stars/oddFEELING/chowbea-axios?style=flat-square&color=10b981" alt="GitHub stars" /></a>
   <a href="https://www.npmjs.com/package/chowbea-axios"><img src="https://img.shields.io/npm/v/chowbea-axios?style=flat-square&color=10b981" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/chowbea-axios"><img src="https://img.shields.io/npm/dm/chowbea-axios?style=flat-square&color=10b981" alt="npm downloads" /></a>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dev": "tsc --watch",
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
     "prepublishOnly": "npm run build",
-    "release:experimental": "npm ci && npm version prerelease --preid=alpha -m \"chore(release): v%s\" && npm publish --tag experimental && git push --follow-tags",
+    "release:experimental": "npm ci && npm test && npm version prerelease --preid=alpha -m \"chore(release): v%s\" && git push --follow-tags",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
Closes #61 (H1 from the [2026-05-04 adoption-readiness audit](https://github.com/oddFEELING/chowbea-axios/blob/main/docs/reviews/2026-05-04-adoption-readiness.md)).

## Summary

First proper CI for the package itself. Three new YAML files plus a README badge.

| File | Purpose |
|---|---|
| `.github/workflows/ci.yml` | Test + build matrix on every PR + push to `main` |
| `.github/workflows/release.yml` | Tag-triggered npm publish with provenance (Trusted Publishing) |
| `.github/dependabot.yml` | Weekly npm + github-actions updates |

## What ci.yml covers

**Test matrix:** `ubuntu-latest × macos-latest × windows-latest` × Node `20 × 22 × 24` = 9 cells per run. `fail-fast: false` so all combinations report independently. Per cell: `npm ci → npm run build → npm test`. 15-minute timeout. First run on this branch was 10/10 green.

**Pack-check job:** runs `npm pack --dry-run --json` and asserts `LICENSE`, `SECURITY.md`, `README.md`, `package.json` are in the tarball, and that no `src/`, `tests/`, `docs/`, `.planning/` files leaked. Catches regressions in the `files` whitelist before they ship.

**Hygiene:**
- Default-deny permissions (`contents: read`)
- Concurrency cancel-in-progress on the same ref
- All third-party actions SHA-pinned (not tag-pinned) — Dependabot will keep them current

## What release.yml does

Trigger: push of a `v*` tag (matches what `npm version` creates).

Steps: checkout → setup-node → install → build → test → version-vs-tag consistency check → `npm publish --provenance --tag experimental`.

Uses **npm Trusted Publishing** (OIDC) — no long-lived NPM_TOKEN secret in this repo. The OIDC token GitHub mints for this workflow proves the publish came from this repo + this exact workflow file; npm verifies it against the Trusted Publisher config on the package settings page and authorizes the publish.

Adopters can verify provenance after install via `npm view chowbea-axios provenance`.

The local `npm run release:experimental` script stays as the manual fallback — but it doesn't have provenance attestation, so once the Trusted Publisher is configured, prefer pushing a tag and letting CI publish.

## ⚠️ One-time setup needed on npmjs.com before release.yml can publish

> **Note:** This is much simpler than the original NPM_TOKEN approach — no secret in this repo, no long-lived credential to rotate. npm's UI now actively warns against the older "Bypass 2FA" token type and recommends Trusted Publishing instead.

1. Sign in to npmjs.com → https://www.npmjs.com/package/chowbea-axios/access
2. Find the **Trusted Publisher** section → **Add publisher**.
3. Fill in:
   - **Publisher:** GitHub Actions
   - **Organization or user:** `oddFEELING`
   - **Repository:** `chowbea-axios`
   - **Workflow filename:** `release.yml`
   - **Environment name:** (leave blank — we don't use GitHub Environments)
4. Save.

That's it. No GitHub secret. Until this is configured, the release workflow will fail with an authentication error if a tag is pushed — but `ci.yml` is unaffected and keeps running on PRs.

## What dependabot.yml does

Two ecosystems on a weekly Monday schedule:
- **npm** — application deps in `package.json`
- **github-actions** — workflow YAML in `.github/workflows/`

Minor + patch updates per ecosystem are grouped into one PR (less noise). Majors stay individual.

`axios` major bumps are ignored for now (peer-shape concern — a major axios bump ripples into adopter code; reconsider when we have runtime-behavior tests covering axios edges).

## Test plan

- [x] All three YAMLs parse cleanly (`yaml.parse()` locally).
- [x] First CI run on this PR: **10/10 green** (3 OS × 3 Node test cells + pack-check).
- [ ] After merge + Trusted Publisher configured on npmjs: push a tag and verify `release.yml` publishes successfully with provenance attestation.

## Audit Highs status after this PR lands

- ✅ H1 (CI) — this PR
- ✅ H2 (createOperations any) — shipped in alpha.22
- ✅ H3 (SECURITY.md) — shipped in alpha.22
- ✅ H5 (LICENSE in files) — shipped in alpha.22
- ⏳ H4 (CHANGELOG) — PR #74 open
- ⏳ H6 (TUI template props) — issue #63 open

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency updates to keep packages current.
  * Established continuous integration workflow to run tests across multiple environments and Node versions.
  * Set up automated release process for npm package publishing.
  * Added CI status badge to README for visibility into build health.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oddFEELING/chowbea-axios/pull/75)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->