### PR TITLE
docs(readme): module format/compat section + label TUI experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Run `chowbea-axios <command> --help` for command-specific flags.
 
 ## Interactive Dashboard
 
+> **Status: experimental.** The TUI is functional but has no automated test coverage today. For CI pipelines, scripted workflows, and any production-adjacent use, prefer the headless commands (`fetch`, `generate`, `watch`, etc.). The dashboard is great for interactive exploration but the headless surface is what we guarantee.
+
 Running `chowbea-axios` with **no command** launches an OpenTUI dashboard with screens for fetch, generate, diff, validate, watch, plugins, env management, and an endpoint inspector. Tabs survive screen navigation, and processes (e.g. `npm run dev`) can be run alongside in the process tab.
 
 The dashboard requires [Bun](https://bun.sh). When invoked under Node, the CLI re-launches itself under Bun automatically. If Bun isn't installed, the CLI falls back to headless mode and prints a hint.
@@ -157,6 +159,15 @@ chowbea-axios init --non-interactive \
 - `sidepanelsCodegen()` — same for `*.panel.tsx` files
 
 Scaffold them via `chowbea-axios init --with-vite-plugins` or `chowbea-axios plugins --setup`. See [docs](https://axios.chowbea.com) for the full registry pattern.
+
+## Compatibility
+
+| | |
+|---|---|
+| **Node** | `>=20` (declared in `engines`; tested in CI on 20 / 22 / 24 across Linux, macOS, Windows) |
+| **Module format** | **ESM only.** `package.json` declares `"type": "module"`. Importing from a CommonJS file with `require("chowbea-axios")` will fail with `ERR_REQUIRE_ESM`. CJS consumers should either use a dynamic `import()` or migrate the importing file to ESM. The `chowbea-axios` CLI binary is unaffected — it works regardless of your project's module format. |
+| **Vite** | Optional peer dep, `>=5.0.0`. Only required if you use the `chowbea-axios/vite` codegen plugins. |
+| **Bun** | Required to launch the interactive TUI (the headless CLI works under Node alone). |
 
 ---
 


### PR DESCRIPTION
Closes #69 (M6) and #67 (M4 via the lightweight alternative path).

Two README-only additions from the [2026-05-04 adoption-readiness audit](https://github.com/oddFEELING/chowbea-axios/blob/main/docs/reviews/2026-05-04-adoption-readiness.md). Both prevent specific real-world friction; total diff is +11 lines.

## Changes

### `## Compatibility` table (new section, closes #69)

Drops in just before the support footer. Covers in one table:

- **Node** — `>=20`, with the explicit "tested in CI on 20 / 22 / 24 across Linux, macOS, Windows" so adopters can see the matrix is real
- **Module format** — calls out **ESM-only** explicitly, names the exact error CJS consumers will see (`ERR_REQUIRE_ESM`), and gives them two paths out (dynamic `import()` or migrate the importing file)
- **Vite** — clarifies it's optional and only needed for the codegen plugins
- **Bun** — clarifies it's only needed for the TUI, not the headless CLI

This closes the gap from the audit: enterprises with legacy CJS codebases would otherwise try `require("chowbea-axios")`, fail, and either file an issue or move on. Documenting the constraint up front avoids both.

### "Status: experimental" callout on `## Interactive Dashboard` (closes #67)

The audit listed two paths for #67:

- **Option A (L effort)** — actually add TUI test coverage
- **Option B (S effort)** — declare TUI experimental in README

This PR takes Option B. It's the right call because:

1. Most adopters use the headless CLI; the TUI is for interactive exploration.
2. Adding meaningful tests for OpenTUI screens is real work (multiple hours, plus ongoing maintenance) — better to do it once adopter feedback validates the demand.
3. Setting the expectation honestly costs us nothing and prevents future bug reports of the "I tried using the TUI in CI and it broke" variety.

The path back to Option A stays open: anytime the TUI gets real test coverage, drop the callout.

## Test plan

- [x] Markdown renders cleanly (eyeballed locally — table, blockquote, sectioning all render in GitHub's MD).
- [x] No code or config changes — CI is purely a markdown-render check.
- [ ] `ci.yml` matrix should pass identically (no source touched).

## Audit Highs status after this lands

- ✅ H1 (CI), H2 (createOps any), H3 (SECURITY.md), H4 (CHANGELOG), H5 (LICENSE in files)
- ⏳ **H6 (TUI template `props: any`)** — issue #63, still the only remaining High

Plus this PR closes two Mediums (M4 alt + M6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added experimental notice for the interactive dashboard, highlighting lack of automated test coverage and recommending headless commands for CI/production environments
  * Added Compatibility section documenting Node version requirements, ESM-only module expectations, Vite peer dependency, and Bun requirements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oddFEELING/chowbea-axios/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->