### PR TITLE
Fix the release pipeline so 2.0.0 (and future releases) actually publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,5 @@
-# release-please — automates versioning + CHANGELOG from conventional commits.
+# release-please — automates versioning + CHANGELOG from conventional commits,
+# AND publishes to npm in the same workflow run when a release is cut.
 #
 # How it works:
 #   1. On every push to `main`, this workflow runs `release-please`.
@@ -11,16 +12,21 @@
 #        - CHANGELOG.md entry generated from the commits
 #        - .release-please-manifest.json updated
 #   4. When you merge that PR, release-please creates a git tag and a
-#      GitHub Release. The tag fires .github/workflows/release.yml,
-#      which publishes to npm with provenance (via Trusted Publishing).
+#      GitHub Release inside this same workflow run. The subsequent
+#      `if: steps.release.outputs.release_created` steps below then build,
+#      test, and `npm publish --provenance` via Trusted Publishing — all
+#      inside this same job, all with the same OIDC token.
 #
-# First-time bootstrap:
-#   release-please-config.json currently has `"release-as": "2.0.0"` for
-#   this package — a one-time override that forces the first release-please
-#   PR to cut exactly 2.0.0 (graduating out of the alpha line) instead of
-#   computing a next version from commit semantics. Remove that field
-#   AFTER 2.0.0 ships; from then on, release-please picks the next
-#   version automatically.
+# Why publish inline (vs. handing off to release.yml on tag-push):
+#   Tags created by a workflow using GITHUB_TOKEN do NOT trigger other
+#   workflows — GitHub's anti-infinite-loop guard. The hand-off pattern
+#   (release-please creates tag → release.yml fires on push:tags) silently
+#   fails. Inline publish in the same workflow run sidesteps the problem
+#   entirely: no cross-workflow trigger, no PAT, no GitHub App needed.
+#
+#   release.yml stays in the repo for the manual tag-push case (the
+#   local `release:experimental` script for off-cycle prereleases — where
+#   the tag IS user-pushed and DOES trigger workflows correctly).
 #
 # Conventional commit cheat sheet:
 #   feat: <subject>           → minor bump   (1.2.3 → 1.3.0)
@@ -31,6 +37,7 @@
 # Permissions:
 #   contents: write        — create commits, tags, releases
 #   pull-requests: write   — open/update the release PR
+#   id-token: write        — OIDC token for npm Trusted Publishing
 name: release-please
 
 on:
@@ -40,17 +47,58 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     # Defense-in-depth: only run on the canonical repo.
     if: github.repository == 'oddFEELING/chowbea-axios'
     steps:
       - name: Run release-please
+        id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           # Manifest-driven config — both files at repo root.
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # The remaining steps only run when release-please actually cut a
+      # release this run (i.e., the user just merged the release PR).
+      # Most pushes to main don't cut a release — they just update or
+      # open the in-flight release PR, and these steps are skipped.
+
+      - name: Checkout (release just cut)
+        if: ${{ steps.release.outputs.release_created }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        if: ${{ steps.release.outputs.release_created }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: npm
+          # Required for Trusted Publishing — tells npm where to send
+          # the publish + OIDC handshake.
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        if: ${{ steps.release.outputs.release_created }}
+        run: npm ci
+
+      - name: Build
+        if: ${{ steps.release.outputs.release_created }}
+        run: npm run build
+
+      - name: Test
+        if: ${{ steps.release.outputs.release_created }}
+        run: npm test
+
+      - name: Publish to npm (Trusted Publishing + provenance)
+        if: ${{ steps.release.outputs.release_created }}
+        # No NODE_AUTH_TOKEN: OIDC token from `id-token: write` is exchanged
+        # for a scoped npm credential at publish time.
+        # No --tag flag: npm picks the dist-tag from the version itself
+        # (stable → latest, prerelease → none).
+        run: npm publish --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,23 @@
 name: release
 
 on:
+  # Primary trigger: a user-pushed tag fires this workflow.
+  # (Tags created by another workflow's GITHUB_TOKEN do NOT trigger this —
+  # see release-please.yml, which now publishes inline instead of relying
+  # on this hand-off.)
   push:
     tags:
       - "v*"
+  # Manual trigger: re-publish a specific tag from the GitHub UI / gh CLI.
+  # Useful when a tag exists but the original publish failed or never fired
+  # (e.g., the v2.0.0 tag created by release-please before the inline
+  # publish refactor — see history).
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to publish (e.g. v2.0.0). Must already exist on origin."
+        required: true
+        type: string
 
 # Default-deny except where required.
 #   contents: read   — checkout
@@ -71,9 +85,19 @@ jobs:
     # npmjs is already scoped to this repo, but the extra guard avoids
     # spending CI minutes on doomed publishes from forks.)
     if: github.repository == 'oddFEELING/chowbea-axios'
+    env:
+      # Unified tag reference for both triggers:
+      #   - push:tags        → github.ref_name is the tag (e.g. "v2.0.0")
+      #   - workflow_dispatch → use the user-supplied input
+      RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
     steps:
-      - name: Checkout
+      - name: Checkout the tagged commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Ensure we publish from the exact commit the tag points at,
+          # not whatever HEAD happens to be on the branch the dispatch
+          # came from.
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -103,7 +127,7 @@ jobs:
         # previous version under a new tag.
         run: |
           PKG_VERSION=$(node -p "require('./package.json').version")
-          TAG_VERSION=${GITHUB_REF_NAME#v}
+          TAG_VERSION=${RELEASE_TAG#v}
           if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
             echo "Version mismatch: package.json=$PKG_VERSION tag=$TAG_VERSION"
             exit 1

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,7 +20,6 @@
   ],
   "packages": {
     ".": {
-      "release-as": "2.0.0",
       "changelog-path": "CHANGELOG.md",
       "package-name": "chowbea-axios"
     }


### PR DESCRIPTION
## Background

`v2.0.0` is tagged on origin but never made it to npm. Root cause: **tags created by a workflow using the default `GITHUB_TOKEN` do not trigger other workflows** — GitHub's anti-infinite-loop guard. The original handoff (release-please.yml creates tag → release.yml fires on `push:tags`) silently dropped the trigger.

```
npm view chowbea-axios dist-tags
# → latest: '1.1.0'   ← still the old line
#   experimental: '2.0.0-alpha.22'
#   alpha: '2.0.0-alpha.21'
```

This PR fixes the pipeline so future releases publish themselves, and gives us a one-time manual path to ship the stuck `v2.0.0`.

## Three commits

### 1. `ci(release-please): publish in-workflow instead of handing off`

Adds the publish steps (checkout / setup-node / install / build / test / `npm publish --provenance`) directly into `release-please.yml`, gated on `steps.release.outputs.release_created`. They only run on the exact workflow run that cut the release — most pushes to `main` just update the in-flight release PR and skip these steps entirely.

Also adds `id-token: write` so the same workflow can do OIDC Trusted Publishing.

**No PAT, no GitHub App, no secret.** The cross-workflow trigger problem is sidestepped because everything happens in one workflow run.

`release.yml` stays as-is — it still handles user-pushed tags from the local `release:experimental` script for off-cycle prereleases, where the user-pushed tag *does* trigger downstream workflows correctly.

### 2. `ci(release-please): drop release-as 2.0.0 override`

The override served its one-time purpose (forcing the first release-please PR to cut exactly `2.0.0`, graduating out of the alpha line). Now that `v2.0.0` exists on origin, leaving the field would cause every future release-please run to re-attempt 2.0.0. Future versions come from conventional-commit semantics automatically.

### 3. `ci(release): add workflow_dispatch trigger for manual republish`

Adds a second trigger to `release.yml` so an existing tag can be republished from the GitHub UI (Actions → release → Run workflow) or via `gh workflow run`. Required for the immediate fix — see "Action plan" below.

Implementation detail: a new `RELEASE_TAG` env var unifies the tag reference across both triggers (`github.ref_name` for `push:tags`, the user input for `workflow_dispatch`). Checkout takes `ref: ${{ env.RELEASE_TAG }}` explicitly so manual dispatch publishes from the tagged commit, not from current `main` HEAD.

## Action plan once this PR merges

1. **Merge this PR.** ci.yml runs and goes green on the changes. release-please.yml runs but `release_created` is false (no release PR to merge), so nothing publishes — just the refactor lands.

2. **Manually trigger `release.yml` to publish v2.0.0**:
   ```
   gh workflow run release.yml --repo oddFEELING/chowbea-axios -f tag=v2.0.0
   ```
   Or via the GitHub UI: Actions → release → Run workflow → tag = `v2.0.0`.

3. **Verify**:
   ```
   npm view chowbea-axios dist-tags
   # → latest: '2.0.0'   ← finally
   npm view chowbea-axios@2.0.0 provenance
   # → attestation pointing at oddFEELING/chowbea-axios + release.yml
   ```

4. **From then on**: any conventional-commit PR you merge updates the release-please PR. Merging that PR publishes the new version automatically, in one workflow run, with provenance. No manual step.

## Test plan

- [x] All YAML / JSON parses locally
- [ ] CI matrix passes on this PR (only workflow + JSON files changed; source untouched; expected uneventful)
- [ ] After merge: `gh workflow run release.yml -f tag=v2.0.0` succeeds and 2.0.0 lands on npm `latest` with provenance
- [ ] (Eventually, on the next merged release PR) verify the inline publish in release-please.yml actually fires and publishes — first real test will be the next minor/patch

## Audit Highs status (unchanged)

- ✅ H1, H2, H3, H4, H5 — shipped
- ⏳ H6 (TUI template `props: any`) — issue #63