### PR TITLE
ci(release): bump publish-side Node to 24 for npm CLI 11.5.1+ (fixes Trusted Publishing 404)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -77,11 +77,24 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          # Node 24 ships npm 11.5.1+, which is required for Trusted
+          # Publishing's OIDC handshake. Node 22 bundles npm 10 where
+          # the handshake silently fails and the registry treats the
+          # publish as anonymous → 404. Provenance signing succeeds on
+          # npm 10 (different code path), making the failure mode look
+          # like an npm permissions issue when it's really an npm CLI
+          # version issue. See https://github.com/npm/cli/issues/9088.
+          node-version: "24"
           cache: npm
           # Required for Trusted Publishing — tells npm where to send
           # the publish + OIDC handshake.
           registry-url: "https://registry.npmjs.org"
+
+      - name: Log toolchain versions (for next-time debugging)
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          echo "node: $(node --version)"
+          echo "npm:  $(npm --version)"
 
       - name: Install dependencies
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,12 +102,24 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          # Node 24 is required for npm CLI >= 11.5.1, which Trusted
+          # Publishing's OIDC handshake depends on. Node 22 bundles
+          # npm 10, where the handshake silently fails and the registry
+          # treats the publish as anonymous → 404 + "is not in this
+          # registry". Provenance signing (a separate code path) still
+          # succeeds on npm 10, which makes this very confusing to
+          # debug. See https://github.com/npm/cli/issues/9088.
+          node-version: "24"
           cache: npm
           # registry-url is still required for Trusted Publishing — it
           # tells npm where to send the publish + OIDC token. We just
           # don't set NODE_AUTH_TOKEN; OIDC handles auth.
           registry-url: "https://registry.npmjs.org"
+
+      - name: Log toolchain versions (for next-time debugging)
+        run: |
+          echo "node: $(node --version)"
+          echo "npm:  $(npm --version)"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Why

The v2.0.0 publish has been failing twice now with the same misleading error:

```
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=...
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/chowbea-axios - Not found
npm error 404
npm error 404  'chowbea-axios@2.0.0' is not in this registry.
```

Looks like a Trusted Publisher config problem; isn't. The Trusted Publisher config on npmjs has been verified correct (oddFEELING/chowbea-axios/release.yml, blank environment).

## Actual root cause

**npm CLI < 11.5.1 silently fails Trusted Publishing's OIDC handshake**, after which the registry treats the PUT as anonymous and rejects it with 404. Confusingly, npm's *provenance signing* uses a separate code path (Sigstore direct, OIDC token) that works on npm 10 — so the workflow shows "Signed provenance statement" and a Sigstore transparency log entry, and *then* dies on the registry call. Symptom = npm permissions issue. Real cause = npm CLI version.

Node 22 (what both publish workflows used) bundles npm 10. Node 24 LTS ships npm 11+. One-line fix in each workflow.

## What this PR changes

- `.github/workflows/release.yml`: `node-version: "22"` → `"24"`
- `.github/workflows/release-please.yml`: same change on the publish-gated block
- Both: new "Log toolchain versions" step before publish so next-time debugging is fast (`node --version` + `npm --version` in the run log)

Total diff: +27 / -2 across two YAML files. Nothing else touched.

## Why we didn't catch this earlier

`ci.yml`'s test matrix already runs on Node 24 — but those cells only `npm ci && npm run build && npm test`, never `npm publish`. The publish-specific failure mode lives in the workflows that don't get matrix coverage.

The new "Log toolchain versions" step is the cheap mitigation. Adding a "dry-run publish" cell to ci.yml's matrix to catch this category in CI is a larger change worth its own issue (will file if you want).

## Test plan

- [x] Both YAML files parse locally
- [ ] CI runs on this PR — only tests will run (no publish; that's tag-triggered or dispatch-triggered)
- [ ] After merge, re-dispatch `release.yml`:
  ```
  gh workflow run release.yml --repo oddFEELING/chowbea-axios -f tag=v2.0.0
  ```
  Expected: same workflow run, but now the new "Log toolchain versions" step prints `npm: 11.x.y` and the publish succeeds.
- [ ] `npm view chowbea-axios dist-tags` → `latest: '2.0.0'`

## Sources

- [npm/cli #9088 — Trusted Publishing requires npm >= 11.5.1](https://github.com/npm/cli/issues/9088)
- [GitHub Discussion #173102](https://github.com/orgs/community/discussions/173102)
- [Medium: npm Trusted Publishers — the weird 404 error and the Node.js 24 fix](https://medium.com/@kenricktan11/npm-trusted-publishers-the-weird-404-error-and-the-node-js-24-fix-a9f1d717a5dd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime to version 24 in release workflows for improved compatibility
  * Added diagnostic logging to capture Node and npm version information during releases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oddFEELING/chowbea-axios/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->