### PR TITLE
feat(helpers)!: strip readOnly fields from requests, writeOnly fields from responses

### DIFF
--- a/src/core/generator.ts
+++ b/src/core/generator.ts
@@ -1157,7 +1157,16 @@ async function generateTypes(
 	logger.info({ specPath, typesPath }, "Generating TypeScript types...");
 
 	try {
-		const ast = await openapiTS(new URL(`file://${specPath}`), hooks);
+		const ast = await openapiTS(new URL(`file://${specPath}`), {
+			// Emit $Read<T> / $Write<T> markers around readOnly / writeOnly
+			// schema properties. The helpers template wraps response types in
+			// `Readable<...>` and request types in `Writable<...>` so that
+			// writeOnly fields drop out of response shapes and readOnly fields
+			// drop out of request bodies — a correctness fix for any spec
+			// using these annotations.
+			readWriteMarkers: true,
+			...hooks,
+		});
 		await writeFile(typesPath, astToString(ast), "utf8");
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
@@ -1339,8 +1348,10 @@ import type {
 	MediaType,
 	OperationRequestBodyContent,
 	PathsWithMethod,
+	Readable,
 	ResponseObjectMap,
 	SuccessResponse,
+	Writable,
 } from "openapi-typescript-helpers";
 import type { components, operations, paths } from "./_generated/api.types";
 
@@ -1420,10 +1431,14 @@ type ExpandRecursively<T> = T extends (...args: infer A) => infer R
  * inferred shape for JSON, multipart, octet-stream — every media type
  * the spec declares — courtesy of \`OperationRequestBodyContent\`.
  *
+ * Wrapped in \`Writable<...>\` so server-controlled \`readOnly\` properties
+ * (e.g. \`id\`, \`createdAt\`) are stripped from request body types — you
+ * can't supply them, the server fills them in.
+ *
  * @example type CreateUserInput = ApiRequestBody<"/api/users", "post">
  */
 export type ApiRequestBody<P extends Paths, M extends HttpMethod> = ExpandRecursively<
-	OperationRequestBodyContent<Operation<P, M>>
+	Writable<OperationRequestBodyContent<Operation<P, M>>>
 >;
 
 /**
@@ -1434,6 +1449,9 @@ export type ApiRequestBody<P extends Paths, M extends HttpMethod> = ExpandRecurs
  * (\`application/json\`, \`application/vnd.api+json\`, etc.). Pass a Media
  * value to narrow to e.g. \`"text/csv"\`, \`"application/octet-stream"\`, or
  * \`"text/event-stream"\` when the spec declares multiple response shapes.
+ *
+ * Wrapped in \`Readable<...>\` so \`writeOnly\` properties (e.g. \`password\`)
+ * are stripped from response types — the server doesn't return them.
  *
  * @example type UserResponse = ApiResponseData<"/api/users/{id}", "get">
  * @example type CreatedResponse = ApiResponseData<"/api/users", "post", 201>
@@ -1447,15 +1465,17 @@ export type ApiResponseData<
 		: ApiStatusCodes<P, M>,
 	Media extends MediaType = \`\${string}/json\`,
 > = ExpandRecursively<
-	FilterKeys<
-		Operation<P, M> extends { responses: infer R }
-			? R extends Record<string | number, unknown>
-				? R[Status & keyof R] extends { content: infer C }
-					? C
+	Readable<
+		FilterKeys<
+			Operation<P, M> extends { responses: infer R }
+				? R extends Record<string | number, unknown>
+					? R[Status & keyof R] extends { content: infer C }
+						? C
+						: never
 					: never
-				: never
-			: never,
-		Media
+				: never,
+			Media
+		>
 	>
 >;
 
@@ -1524,7 +1544,7 @@ type OperationPositiveStatus<OpId extends keyof operations> =
  * @see Use concrete types in _generated/api.contracts.ts for cmd+click navigation
  */
 export type ServerRequestBody<OpId extends keyof operations> = ExpandRecursively<
-	OperationRequestBodyContent<operations[OpId]>
+	Writable<OperationRequestBodyContent<operations[OpId]>>
 >;
 
 /**
@@ -1566,15 +1586,17 @@ export type ServerResponseType<
 	Status extends OperationStatusCodes<OpId> = OperationPositiveStatus<OpId>,
 	Media extends MediaType = \`\${string}/json\`,
 > = ExpandRecursively<
-	FilterKeys<
-		operations[OpId] extends { responses: infer R }
-			? R extends Record<string | number, unknown>
-				? R[Status & keyof R] extends { content: infer C }
-					? C
+	Readable<
+		FilterKeys<
+			operations[OpId] extends { responses: infer R }
+				? R extends Record<string | number, unknown>
+					? R[Status & keyof R] extends { content: infer C }
+						? C
+						: never
 					: never
-				: never
-			: never,
-		Media
+				: never,
+			Media
+		>
 	>
 >;
 
@@ -1584,7 +1606,7 @@ export type ServerResponseType<
  * \`SuccessResponse<ResponseObjectMap<operations[OpId]>>\`.
  */
 export type ServerSuccessResponse<OpId extends keyof operations> = ExpandRecursively<
-	SuccessResponse<ResponseObjectMap<operations[OpId]>>
+	Readable<SuccessResponse<ResponseObjectMap<operations[OpId]>>>
 >;
 
 /**

--- a/tests/generator.test.snap
+++ b/tests/generator.test.snap
@@ -735,8 +735,10 @@ import type {
 	MediaType,
 	OperationRequestBodyContent,
 	PathsWithMethod,
+	Readable,
 	ResponseObjectMap,
 	SuccessResponse,
+	Writable,
 } from "openapi-typescript-helpers";
 import type { components, operations, paths } from "./_generated/api.types";
 
@@ -816,10 +818,14 @@ type ExpandRecursively<T> = T extends (...args: infer A) => infer R
  * inferred shape for JSON, multipart, octet-stream — every media type
  * the spec declares — courtesy of \`OperationRequestBodyContent\`.
  *
+ * Wrapped in \`Writable<...>\` so server-controlled \`readOnly\` properties
+ * (e.g. \`id\`, \`createdAt\`) are stripped from request body types — you
+ * can't supply them, the server fills them in.
+ *
  * @example type CreateUserInput = ApiRequestBody<"/api/users", "post">
  */
 export type ApiRequestBody<P extends Paths, M extends HttpMethod> = ExpandRecursively<
-	OperationRequestBodyContent<Operation<P, M>>
+	Writable<OperationRequestBodyContent<Operation<P, M>>>
 >;
 
 /**
@@ -830,6 +836,9 @@ export type ApiRequestBody<P extends Paths, M extends HttpMethod> = ExpandRecurs
  * (\`application/json\`, \`application/vnd.api+json\`, etc.). Pass a Media
  * value to narrow to e.g. \`"text/csv"\`, \`"application/octet-stream"\`, or
  * \`"text/event-stream"\` when the spec declares multiple response shapes.
+ *
+ * Wrapped in \`Readable<...>\` so \`writeOnly\` properties (e.g. \`password\`)
+ * are stripped from response types — the server doesn't return them.
  *
  * @example type UserResponse = ApiResponseData<"/api/users/{id}", "get">
  * @example type CreatedResponse = ApiResponseData<"/api/users", "post", 201>
@@ -843,15 +852,17 @@ export type ApiResponseData<
 		: ApiStatusCodes<P, M>,
 	Media extends MediaType = \`\${string}/json\`,
 > = ExpandRecursively<
-	FilterKeys<
-		Operation<P, M> extends { responses: infer R }
-			? R extends Record<string | number, unknown>
-				? R[Status & keyof R] extends { content: infer C }
-					? C
+	Readable<
+		FilterKeys<
+			Operation<P, M> extends { responses: infer R }
+				? R extends Record<string | number, unknown>
+					? R[Status & keyof R] extends { content: infer C }
+						? C
+						: never
 					: never
-				: never
-			: never,
-		Media
+				: never,
+			Media
+		>
 	>
 >;
 
@@ -920,7 +931,7 @@ type OperationPositiveStatus<OpId extends keyof operations> =
  * @see Use concrete types in _generated/api.contracts.ts for cmd+click navigation
  */
 export type ServerRequestBody<OpId extends keyof operations> = ExpandRecursively<
-	OperationRequestBodyContent<operations[OpId]>
+	Writable<OperationRequestBodyContent<operations[OpId]>>
 >;
 
 /**
@@ -962,15 +973,17 @@ export type ServerResponseType<
 	Status extends OperationStatusCodes<OpId> = OperationPositiveStatus<OpId>,
 	Media extends MediaType = \`\${string}/json\`,
 > = ExpandRecursively<
-	FilterKeys<
-		operations[OpId] extends { responses: infer R }
-			? R extends Record<string | number, unknown>
-				? R[Status & keyof R] extends { content: infer C }
-					? C
+	Readable<
+		FilterKeys<
+			operations[OpId] extends { responses: infer R }
+				? R extends Record<string | number, unknown>
+					? R[Status & keyof R] extends { content: infer C }
+						? C
+						: never
 					: never
-				: never
-			: never,
-		Media
+				: never,
+			Media
+		>
 	>
 >;
 
@@ -980,7 +993,7 @@ export type ServerResponseType<
  * \`SuccessResponse<ResponseObjectMap<operations[OpId]>>\`.
  */
 export type ServerSuccessResponse<OpId extends keyof operations> = ExpandRecursively<
-	SuccessResponse<ResponseObjectMap<operations[OpId]>>
+	Readable<SuccessResponse<ResponseObjectMap<operations[OpId]>>>
 >;
 
 /**

--- a/tests/types/api-helpers.test-d.ts
+++ b/tests/types/api-helpers.test-d.ts
@@ -232,6 +232,72 @@ describe("ServerRequestBody / ServerRequestParams / ServerResponseType — opera
 	});
 });
 
+describe("readOnly / writeOnly marker handling (L1)", () => {
+	// The Account schema in the fixture wraps `id` and `createdAt` in
+	// `$Read<...>` (readOnly) and `password` in `$Write<...>` (writeOnly),
+	// matching what openapi-typescript emits when readWriteMarkers: true.
+
+	it("ApiResponseData strips writeOnly fields from response types", () => {
+		// Reading an account should NEVER include `password` — the server
+		// doesn't return it.
+		type Got = ApiResponseData<"/accounts/{id}", "get">;
+		expectTypeOf<Got>().toMatchTypeOf<{
+			id: string;
+			email: string;
+			name: string;
+			createdAt?: string;
+		}>();
+		// password must not appear in the response shape.
+		expectTypeOf<Got>().not.toMatchTypeOf<{ password: string }>();
+	});
+
+	it("ApiResponseData unwraps $Read markers (server-controlled fields stay)", () => {
+		type Got = ApiResponseData<"/accounts/{id}", "get">;
+		// `id` was $Read<string> on the wire, should appear as plain string here.
+		expectTypeOf<Got>().toMatchTypeOf<{ id: string }>();
+	});
+
+	it("ApiRequestBody strips readOnly fields from request body types", () => {
+		// Updating an account must NOT accept `id` or `createdAt` —
+		// those are server-set and would be rejected.
+		type Got = ApiRequestBody<"/accounts/{id}", "patch">;
+		expectTypeOf<Got>().toMatchTypeOf<{
+			email: string;
+			name: string;
+			password?: string;
+		}>();
+		// readOnly fields must not appear as required-or-supplied fields.
+		expectTypeOf<Got>().not.toMatchTypeOf<{ id: string }>();
+		expectTypeOf<Got>().not.toMatchTypeOf<{ createdAt: string }>();
+	});
+
+	it("ApiRequestBody unwraps $Write markers (writeable fields stay)", () => {
+		type Got = ApiRequestBody<"/accounts/{id}", "patch">;
+		// `password` was $Write<string> on the wire, should appear as plain string.
+		expectTypeOf<Got>().toMatchTypeOf<{ password?: string }>();
+	});
+
+	it("ServerRequestBody respects the same stripping by operation id", () => {
+		type Got = ServerRequestBody<"updateAccount">;
+		expectTypeOf<Got>().toMatchTypeOf<{
+			email: string;
+			name: string;
+			password?: string;
+		}>();
+		expectTypeOf<Got>().not.toMatchTypeOf<{ id: string }>();
+	});
+
+	it("ServerResponseType respects writeOnly stripping by operation id", () => {
+		type Got = ServerResponseType<"getAccount">;
+		expectTypeOf<Got>().toMatchTypeOf<{
+			id: string;
+			email: string;
+			name: string;
+		}>();
+		expectTypeOf<Got>().not.toMatchTypeOf<{ password: string }>();
+	});
+});
+
 describe("ServerModel — component schema resolution", () => {
 	it("resolves a named schema", () => {
 		expectTypeOf<ServerModel<"User">>().toEqualTypeOf<User>();

--- a/tests/types/fixtures/sample-api.helpers.ts
+++ b/tests/types/fixtures/sample-api.helpers.ts
@@ -16,8 +16,10 @@ import type {
 	MediaType,
 	OperationRequestBodyContent,
 	PathsWithMethod,
+	Readable,
 	ResponseObjectMap,
 	SuccessResponse,
+	Writable,
 } from "openapi-typescript-helpers";
 import type { components, operations, paths } from "./sample-api.types.js";
 
@@ -97,10 +99,14 @@ type ExpandRecursively<T> = T extends (...args: infer A) => infer R
  * inferred shape for JSON, multipart, octet-stream — every media type
  * the spec declares — courtesy of `OperationRequestBodyContent`.
  *
+ * Wrapped in `Writable<...>` so server-controlled `readOnly` properties
+ * (e.g. `id`, `createdAt`) are stripped from request body types — you
+ * can't supply them, the server fills them in.
+ *
  * @example type CreateUserInput = ApiRequestBody<"/api/users", "post">
  */
 export type ApiRequestBody<P extends Paths, M extends HttpMethod> = ExpandRecursively<
-	OperationRequestBodyContent<Operation<P, M>>
+	Writable<OperationRequestBodyContent<Operation<P, M>>>
 >;
 
 /**
@@ -111,6 +117,9 @@ export type ApiRequestBody<P extends Paths, M extends HttpMethod> = ExpandRecurs
  * (`application/json`, `application/vnd.api+json`, etc.). Pass a Media
  * value to narrow to e.g. `"text/csv"`, `"application/octet-stream"`, or
  * `"text/event-stream"` when the spec declares multiple response shapes.
+ *
+ * Wrapped in `Readable<...>` so `writeOnly` properties (e.g. `password`)
+ * are stripped from response types — the server doesn't return them.
  *
  * @example type UserResponse = ApiResponseData<"/api/users/{id}", "get">
  * @example type CreatedResponse = ApiResponseData<"/api/users", "post", 201>
@@ -124,15 +133,17 @@ export type ApiResponseData<
 		: ApiStatusCodes<P, M>,
 	Media extends MediaType = `${string}/json`,
 > = ExpandRecursively<
-	FilterKeys<
-		Operation<P, M> extends { responses: infer R }
-			? R extends Record<string | number, unknown>
-				? R[Status & keyof R] extends { content: infer C }
-					? C
+	Readable<
+		FilterKeys<
+			Operation<P, M> extends { responses: infer R }
+				? R extends Record<string | number, unknown>
+					? R[Status & keyof R] extends { content: infer C }
+						? C
+						: never
 					: never
-				: never
-			: never,
-		Media
+				: never,
+			Media
+		>
 	>
 >;
 
@@ -201,7 +212,7 @@ type OperationPositiveStatus<OpId extends keyof operations> =
  * @see Use concrete types in _generated/api.contracts.ts for cmd+click navigation
  */
 export type ServerRequestBody<OpId extends keyof operations> = ExpandRecursively<
-	OperationRequestBodyContent<operations[OpId]>
+	Writable<OperationRequestBodyContent<operations[OpId]>>
 >;
 
 /**
@@ -243,15 +254,17 @@ export type ServerResponseType<
 	Status extends OperationStatusCodes<OpId> = OperationPositiveStatus<OpId>,
 	Media extends MediaType = `${string}/json`,
 > = ExpandRecursively<
-	FilterKeys<
-		operations[OpId] extends { responses: infer R }
-			? R extends Record<string | number, unknown>
-				? R[Status & keyof R] extends { content: infer C }
-					? C
+	Readable<
+		FilterKeys<
+			operations[OpId] extends { responses: infer R }
+				? R extends Record<string | number, unknown>
+					? R[Status & keyof R] extends { content: infer C }
+						? C
+						: never
 					: never
-				: never
-			: never,
-		Media
+				: never,
+			Media
+		>
 	>
 >;
 
@@ -261,7 +274,7 @@ export type ServerResponseType<
  * `SuccessResponse<ResponseObjectMap<operations[OpId]>>`.
  */
 export type ServerSuccessResponse<OpId extends keyof operations> = ExpandRecursively<
-	SuccessResponse<ResponseObjectMap<operations[OpId]>>
+	Readable<SuccessResponse<ResponseObjectMap<operations[OpId]>>>
 >;
 
 /**

--- a/tests/types/fixtures/sample-api.types.ts
+++ b/tests/types/fixtures/sample-api.types.ts
@@ -19,6 +19,14 @@
  * be added when L1 lands and the helpers gain `$Read` / `$Write` awareness.
  */
 
+/**
+ * `$Read<T>` / `$Write<T>` markers — inlined exactly the way
+ * `openapi-typescript` emits them when `readWriteMarkers: true` is on.
+ * Real generated files will contain these definitions at the top.
+ */
+export type $Read<T> = { readonly $read: T };
+export type $Write<T> = { readonly $write: T };
+
 export interface paths {
 	"/users": {
 		get: operations["listUsers"];
@@ -56,6 +64,13 @@ export interface paths {
 		// Multi-media endpoint — same status, different content types.
 		get: operations["downloadReport"];
 	};
+	"/accounts/{id}": {
+		// Schema uses readOnly/writeOnly. The request body type should
+		// exclude `id`/`createdAt` (server-controlled), the response
+		// type should exclude `password` (writeOnly, never returned).
+		get: operations["getAccount"];
+		patch: operations["updateAccount"];
+	};
 }
 
 export interface components {
@@ -87,6 +102,15 @@ export interface components {
 			id: string;
 			generatedAt: string;
 			rowCount: number;
+		};
+		Account: {
+			// Marker-wrapped properties match openapi-typescript's emission
+			// when readWriteMarkers: true is enabled.
+			id: $Read<string>;
+			createdAt?: $Read<string>;
+			email: string;
+			name: string;
+			password?: $Write<string>;
 		};
 	};
 	responses: never;
@@ -248,6 +272,42 @@ export interface operations {
 			201: {
 				content: {
 					"application/json": components["schemas"]["UploadResult"];
+				};
+			};
+		};
+	};
+	getAccount: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: { id: string };
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			200: {
+				content: {
+					"application/json": components["schemas"]["Account"];
+				};
+			};
+		};
+	};
+	updateAccount: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: { id: string };
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				"application/json": components["schemas"]["Account"];
+			};
+		};
+		responses: {
+			200: {
+				content: {
+					"application/json": components["schemas"]["Account"];
 				};
 			};
 		};


### PR DESCRIPTION
**Stacked on #86. Targets `oddFEELING/openapi-typescript-axios` — please merge #86 first, then this PR re-bases against `main`.**

## Why

OpenAPI's `readOnly: true` and `writeOnly: true` annotations exist for a reason: server-controlled fields like `id` and `createdAt` shouldn't be in request bodies (the server ignores them anyway), and sensitive fields like `password` shouldn't be in response shapes (the server never sends them back).

Before this PR, chowbea-axios's generated helpers ignored both annotations. The type for a "create user" request body included `id`, and the type for "get user" responses included `password`. The type system was silently lying — letting consumers reference fields that either get ignored on the wire or never arrive.

This PR turns on openapi-typescript's `readWriteMarkers: true` option (which emits `$Read<T>` / `$Write<T>` markers inside generated types) and wraps the chowbea helpers in `Writable<...>` / `Readable<...>` resolvers from `openapi-typescript-helpers` to strip the markers in the right direction per usage.

## What changed

- `src/core/generator.ts:1159-1170` — `openapiTS()` call passes `readWriteMarkers: true`.
- `src/core/generator.ts` — helpers template imports `Readable` and `Writable` from `openapi-typescript-helpers`; wraps response helpers (`ApiResponseData`, `ServerResponseType`, `ServerSuccessResponse`) in `Readable<...>` and request helpers (`ApiRequestBody`, `ServerRequestBody`) in `Writable<...>`.
- `tests/types/fixtures/sample-api.types.ts` — adds an `Account` schema with inline `$Read<string>` / `$Write<string>` markers matching the upstream emission shape; adds `getAccount` / `updateAccount` operations exercising both stripping directions.
- `tests/types/api-helpers.test-d.ts` — 6 new `expectTypeOf` assertions verify `password` doesn't appear in account response types and `id` doesn't appear in account request types, for both path-keyed and operationId-keyed helpers.
- `tests/types/fixtures/sample-api.helpers.ts` — vendored fixture regenerated to match the new template.
- `tests/generator.test.snap` — helpers snapshot regenerated.

### Concrete consumer effect

Given a `User` schema with `id` readOnly and `password` writeOnly:

```ts
// Before — both types were just User, letting consumers misuse them
type UserResponse = ApiResponseData<"/users/{id}", "get">; // includes password
type UserCreate   = ApiRequestBody<"/users", "post">;        // includes id

// After — types match what the wire actually allows
type UserResponse = ApiResponseData<"/users/{id}", "get">; // password stripped
type UserCreate   = ApiRequestBody<"/users", "post">;        // id stripped
```

## Breaking changes

🚨 **This is a v3.0.0 cut.** Consumer code that relied on the old, overly-permissive shapes will fail to compile. Specifically code that:

- Sets `id` / `createdAt` / other `readOnly` fields in a request body
- Reads `password` / other `writeOnly` fields off a response

The fix is almost always to **remove** those reads or writes — the server was either ignoring them (readOnly → request) or never sending them (writeOnly → response). The "fix" is the type system finally telling you about a long-latent bug.

**Migration note:** Existing projects whose `api.helpers.ts` was generated under v2.x are *not* automatically updated — the helpers file is "generated once, never overwritten" by design. They keep their old types until they manually regenerate. A future migration helper (or a `--force-regenerate-helpers` CLI flag) would close that gap; not in this PR.

## Test plan

- [x] `npm test` — 142 runtime tests pass (no change vs #86 — runtime behaviour identical)
- [x] `npm run test:types` — 36 type-level assertions pass (was 30 in #86; +6 read/write stripping tests)
- [x] `npm run test:types:strict` — vendored fixture compiles cleanly under strict mode
- [x] Pack-check confirms no new files leak into the published tarball

## Sources / related

- Stacked on #86 which adopted the upstream helpers vocabulary that this PR's wrappers depend on.
- `openapi-typescript-helpers`'s `$Read` / `$Write` / `Readable` / `Writable` types at the helpers source documented inline at line 113550-113595 of the reference bundle.
- Upstream config option: [`readWriteMarkers` in `OpenAPITSOptions`](https://openapi-ts.dev/cli#flags).
