### PR TITLE
docs(release): point trusted-publisher setup at release-please.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,6 +38,12 @@
 #   contents: write        — create commits, tags, releases
 #   pull-requests: write   — open/update the release PR
 #   id-token: write        — OIDC token for npm Trusted Publishing
+#
+# npm Trusted Publisher setup (one-time, on npmjs.com — NO GitHub secret):
+#   On https://www.npmjs.com/package/chowbea-axios/access → Trusted Publisher,
+#   add an entry with Workflow filename: `release-please.yml` (this file —
+#   not `release.yml`, which only handles the off-cycle tag-push fallback).
+#   See .github/workflows/release.yml for the full walkthrough.
 name: release-please
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,22 +15,33 @@
 # want them under the `alpha` or `experimental` tag, set it manually
 # after the publish lands: `npm dist-tag add chowbea-axios@<ver> alpha`.
 #
+# PRIMARY publish path: release-please.yml (inline publish on merge).
+# This workflow (release.yml) is only the FALLBACK for off-cycle tag-pushes,
+# typically the `npm run release:experimental` script. The Trusted Publisher
+# entry for `release-please.yml` is the one that must always exist; the
+# entry for `release.yml` is optional and only needed if you actually use
+# the experimental tag-push path.
+#
 # REQUIRED SETUP (one-time, on npmjs.com — NO GitHub secret needed):
 #   1. Sign in to npmjs.com and go to the chowbea-axios package settings:
 #        https://www.npmjs.com/package/chowbea-axios/access
 #   2. Find the "Trusted Publisher" section → Add publisher.
-#   3. Fill in:
+#   3. Fill in (primary, required for every release):
 #        Publisher:           GitHub Actions
 #        Organization or user: oddFEELING
 #        Repository:          chowbea-axios
-#        Workflow filename:   release.yml
+#        Workflow filename:   release-please.yml
 #        Environment name:    (leave blank — we don't use GitHub Environments)
 #   4. Save.
+#   5. OPTIONAL: add a SECOND publisher entry with Workflow filename
+#      `release.yml` if you also want to use the experimental tag-push
+#      path. Skip this if you only release through release-please.
 #
 # That's the entire setup. No NPM_TOKEN secret in this repo, no long-lived
-# access tokens to rotate. The OIDC token GitHub mints for this workflow
-# proves the publish came from this repo + this workflow file; npm verifies
-# it against the Trusted Publisher config and authorizes the publish.
+# access tokens to rotate. The OIDC token GitHub mints for whichever
+# workflow runs proves the publish came from this repo + that workflow
+# file; npm verifies it against the matching Trusted Publisher entry and
+# authorizes the publish.
 #
 # Adopters can verify provenance after install via:
 #   npm view chowbea-axios provenance


### PR DESCRIPTION
## Why

The inline publish moved into `release-please.yml` in #84, but the trusted-publisher setup walkthrough in `release.yml` still told readers (and future-us) to authorize the workflow filename `release.yml`. That mismatch is exactly what caused 2.1.0 and 2.1.1 to fail publishing with 404 — npm received an OIDC token claiming `release-please.yml` and rejected it because only `release.yml` was registered as an authorized publisher.

The npm-side configuration has already been updated by the package owner to authorize `release-please.yml`. This PR makes the in-repo docs match that reality so the next person who reads either workflow file doesn't repeat the mistake.

## What changed

- `.github/workflows/release.yml` — clarified the comment block: `release-please.yml` is the primary publish path and the trusted publisher you must configure for every release; `release.yml` is the optional fallback for the experimental tag-push path. Setup walkthrough updated to use the correct workflow filename.
- `.github/workflows/release-please.yml` — added a brief setup note in the preamble so the trusted-publisher requirement is discoverable from the file that actually publishes, with a pointer to the full walkthrough.

No workflow logic changes — comments only.

## Breaking changes

None.

## Test plan

- [x] No CI test changes — comment-only diff.
- [x] PR template enforcement check will run and confirm the body has the required sections.
- [ ] Next merged release should publish successfully now that the docs reflect the npm-side configuration.

## Sources / related

- #84 — moved the publish inline into `release-please.yml`
- #94 — 2.1.1 release attempt that failed at the publish step (run 26404050338)
- Earlier 2.1.0 failure: run 25967252713 — same 404 from npm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration documentation to clarify release process setup and Trusted Publisher requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oddFEELING/chowbea-axios/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->