### PR TITLE
feat(cli): Add local-first execution with project/global indicator

### DIFF
--- a/src/core/actions/status.ts
+++ b/src/core/actions/status.ts
@@ -13,6 +13,12 @@ import { formatError } from "../errors.js";
 import { hasLocalSpec, loadCacheMetadata, loadLocalSpec } from "../fetcher.js";
 import type { CacheMetadata } from "../fetcher.js";
 import { HTTP_METHODS } from "../http-methods.js";
+import {
+	executionSource,
+	findRunningPackageRoot,
+	resolveLocalInstall,
+} from "../local-resolution.js";
+import type { ExecutionSource } from "../local-resolution.js";
 
 /**
  * Options for the status action.
@@ -59,6 +65,8 @@ export interface StatusResult {
 	methodCounts: MethodCounts | null;
 	fileStatus: FileStatus;
 	projectRoot: string;
+	/** Whether the running CLI is the project-local install or a global one. */
+	executionSource: ExecutionSource;
 }
 
 /**
@@ -176,6 +184,12 @@ export async function executeStatus(
 			: null;
 		const fileStatus = await checkGeneratedFiles(outputPaths);
 
+		// Which install is actually running — project-local or global.
+		const runtimeSource = executionSource({
+			runningRoot: findRunningPackageRoot(import.meta.url),
+			localRoot: resolveLocalInstall(process.cwd())?.root ?? null,
+		});
+
 		// Resolve displayed source: prefer local spec_file when set, else api_endpoint.
 		const isLocalSpec = Boolean(config.spec_file);
 		const endpoint = isLocalSpec
@@ -193,6 +207,7 @@ export async function executeStatus(
 			methodCounts,
 			fileStatus,
 			projectRoot,
+			executionSource: runtimeSource,
 		};
 	} catch (error) {
 		logger.error(formatError(error));

--- a/src/core/local-resolution.ts
+++ b/src/core/local-resolution.ts
@@ -1,0 +1,128 @@
+/**
+ * Local-first execution resolution.
+ *
+ * When the globally-installed `chowbea-axios` is run inside a project that has
+ * its own copy as a dependency, the CLI hands off to that project-local copy so
+ * the pinned version is what actually runs (mirroring how the router already
+ * re-execs itself under Bun). These helpers decide whether to delegate and
+ * report which install is running, kept pure so they can be unit-tested with
+ * injected paths.
+ */
+
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface LocalInstall {
+	/** Canonical root of the project-local `chowbea-axios` package. */
+	root: string;
+	/** Absolute path to its `bin` entry. */
+	binPath: string;
+}
+
+export type ExecutionSource = "project" | "global";
+
+export type DelegationDecision =
+	| { action: "run" }
+	| { action: "delegate"; binPath: string };
+
+/**
+ * Decide whether the running process should hand off to a project-local
+ * install. Pure: the caller resolves `runningRoot` and `localInstall` (both
+ * canonicalised) and passes argv/env.
+ */
+export function decideDelegation(params: {
+	runningRoot: string;
+	localInstall: LocalInstall | null;
+	argv: string[];
+	env: NodeJS.ProcessEnv;
+}): DelegationDecision {
+	const { runningRoot, localInstall, argv, env } = params;
+
+	// Loop guard: a delegated child must never delegate again.
+	if (env.CHOWBEA_LOCAL_DELEGATED === "1") return { action: "run" };
+	// User opt-outs.
+	if (env.CHOWBEA_NO_DELEGATE === "1") return { action: "run" };
+	if (argv.includes("--global")) return { action: "run" };
+
+	if (!localInstall) return { action: "run" }; // no project-local copy
+	if (localInstall.root === runningRoot) return { action: "run" }; // already it
+
+	return { action: "delegate", binPath: localInstall.binPath };
+}
+
+/**
+ * Whether the currently-running install is the project-local one or a global
+ * one. Pure string comparison of canonicalised roots.
+ */
+export function executionSource(params: {
+	runningRoot: string;
+	localRoot: string | null;
+}): ExecutionSource {
+	const { runningRoot, localRoot } = params;
+	if (!localRoot) return "global";
+	return localRoot === runningRoot ? "project" : "global";
+}
+
+/** Canonicalise a path (resolve symlinks); fall back to the input on failure. */
+function canonical(p: string): string {
+	try {
+		return realpathSync(p);
+	} catch {
+		return p;
+	}
+}
+
+/**
+ * Find the package root of the running CLI by walking up from a module's
+ * `import.meta.url` to the nearest `package.json`. Depth-independent, so it
+ * works from `dist/router.js`, `dist/tui/screens/home.js`, or source.
+ */
+export function findRunningPackageRoot(importMetaUrl: string): string {
+	let dir = dirname(fileURLToPath(importMetaUrl));
+	while (true) {
+		if (existsSync(join(dir, "package.json"))) return canonical(dir);
+		const parent = dirname(dir);
+		if (parent === dir) return canonical(dir); // filesystem root — give up
+		dir = parent;
+	}
+}
+
+/**
+ * Resolve the project-local `chowbea-axios` install for a working directory by
+ * walking up the `node_modules` chain — returning its canonical root and `bin`
+ * entry, or `null` if the project has no local copy.
+ *
+ * A manual walk (rather than `require.resolve`) is deliberate: the running CLI
+ * is itself named `chowbea-axios`, so `require.resolve("chowbea-axios/...")`
+ * would self-reference the running package (and hit its `exports` map) instead
+ * of finding the project-local dependency.
+ */
+export function resolveLocalInstall(cwd: string): LocalInstall | null {
+	let dir = canonical(cwd);
+	while (true) {
+		const pkgJsonPath = join(
+			dir,
+			"node_modules",
+			"chowbea-axios",
+			"package.json",
+		);
+		if (existsSync(pkgJsonPath)) {
+			try {
+				const root = canonical(dirname(pkgJsonPath));
+				const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf8")) as {
+					bin?: string | Record<string, string>;
+				};
+				const binRel =
+					typeof pkg.bin === "string" ? pkg.bin : pkg.bin?.["chowbea-axios"];
+				if (!binRel) return null;
+				return { root, binPath: join(root, binRel) };
+			} catch {
+				return null;
+			}
+		}
+		const parent = dirname(dir);
+		if (parent === dir) return null; // filesystem root — no local copy
+		dir = parent;
+	}
+}

--- a/src/headless/formatters.ts
+++ b/src/headless/formatters.ts
@@ -37,6 +37,16 @@ export function formatStatusOutput(result: StatusResult): string {
 	lines.push(`  ${pc.bold("chowbea-axios status")}`);
 	lines.push("");
 
+	// Which install is running — project-local vs global.
+	const runLabel =
+		result.executionSource === "project"
+			? pc.green("project install")
+			: pc.dim("global install");
+	lines.push(
+		`  ${pc.cyan("●")} ${pc.bold(pc.cyan(pad("running")))}${runLabel}`,
+	);
+	lines.push("");
+
 	// Config section
 	lines.push(
 		`  ${pc.cyan("\u25cf")} ${pc.bold(pc.cyan(pad("config")))}${result.configPath}${result.wasCreated ? pc.yellow(" (created)") : ""}`,

--- a/src/headless/runner.ts
+++ b/src/headless/runner.ts
@@ -18,6 +18,11 @@ import type { FetchActionOptions } from "../core/actions/fetch.js";
 import { executeGenerate } from "../core/actions/generate.js";
 import type { GenerateActionOptions } from "../core/actions/generate.js";
 import { executeStatus } from "../core/actions/status.js";
+import {
+	executionSource,
+	findRunningPackageRoot,
+	resolveLocalInstall,
+} from "../core/local-resolution.js";
 import { executeDiff } from "../core/actions/diff.js";
 import { executeValidate } from "../core/actions/validate.js";
 import { executeWatch } from "../core/actions/watch.js";
@@ -758,7 +763,9 @@ export async function runHeadless(
 	args: string[],
 ): Promise<void> {
 	// Strip the command name and global-only flags from args for sub-parsers
-	const commandArgs = args.filter((a) => a !== command && a !== "--headless");
+	const commandArgs = args.filter(
+		(a) => a !== command && a !== "--headless" && a !== "--global",
+	);
 
 	// --version
 	if (args.includes("--version")) {
@@ -769,7 +776,11 @@ export async function runHeadless(
 			const thisDir = dirname(fileURLToPath(import.meta.url));
 			const pkgPath = resolve(thisDir, "..", "..", "package.json");
 			const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version: string };
-			console.log(`chowbea-axios v${pkg.version}`);
+			const source = executionSource({
+				runningRoot: findRunningPackageRoot(import.meta.url),
+				localRoot: resolveLocalInstall(process.cwd())?.root ?? null,
+			});
+			console.log(`chowbea-axios v${pkg.version} (${source})`);
 		} catch {
 			console.log("chowbea-axios (unknown version)");
 		}

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,6 +2,11 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { resolve, dirname } from "node:path";
 import { commandExists, resolveCommand } from "./core/pm.js";
+import {
+	decideDelegation,
+	findRunningPackageRoot,
+	resolveLocalInstall,
+} from "./core/local-resolution.js";
 
 /**
  * Check if Bun is available on the system.
@@ -43,9 +48,49 @@ function relaunchWithBun(argv: string[]): boolean {
 }
 
 /**
+ * Local-first execution. If the working directory has its own chowbea-axios
+ * install and we are NOT it (i.e. the global one is running), hand off to the
+ * project-local bin so the pinned version runs. Mirrors relaunchWithBun: on
+ * delegation the child runs to completion and we exit with its status; if the
+ * spawn itself fails we warn and continue with the current process.
+ */
+function maybeDelegateToLocal(argv: string[]): void {
+	const decision = decideDelegation({
+		runningRoot: findRunningPackageRoot(import.meta.url),
+		localInstall: resolveLocalInstall(process.cwd()),
+		argv,
+		env: process.env,
+	});
+	if (decision.action !== "delegate") return;
+
+	// No `shell: true` — user argv flows through unescaped. The sentinel env var
+	// stops the delegated child from delegating back. Issue #16.
+	const result = spawnSync(
+		process.execPath,
+		[decision.binPath, ...argv.slice(2)],
+		{
+			stdio: "inherit",
+			env: { ...process.env, CHOWBEA_LOCAL_DELEGATED: "1" },
+		},
+	);
+
+	if (result.error) {
+		console.error(
+			`chowbea-axios: could not run the project-local install ` +
+				`(${result.error.message}); continuing with the global one.`,
+		);
+		return;
+	}
+	process.exit(result.status ?? 0);
+}
+
+/**
  * Command router -- dispatches to TUI dashboard or headless CLI.
  */
 export async function route(argv: string[]): Promise<void> {
+	// Local-first: hand off to a project-local install before anything else.
+	maybeDelegateToLocal(argv);
+
 	const args = argv.slice(2); // strip runtime and script path
 	const command = args.find((a) => !a.startsWith("-"));
 	const hasFlag =

--- a/src/router.ts
+++ b/src/router.ts
@@ -81,7 +81,16 @@ function maybeDelegateToLocal(argv: string[]): void {
 		);
 		return;
 	}
-	process.exit(result.status ?? 0);
+	if (typeof result.status === "number") {
+		process.exit(result.status);
+	}
+	if (result.signal) {
+		// The child was killed by a signal — re-raise it so we terminate the
+		// same way instead of masking it as a clean (exit 0) success.
+		process.kill(process.pid, result.signal);
+		return;
+	}
+	process.exit(1);
 }
 
 /**

--- a/src/tui/screens/home.tsx
+++ b/src/tui/screens/home.tsx
@@ -121,6 +121,7 @@ export function HomeScreen() {
 				<box flexDirection="row">
 					<text fg={colors.fgDim}>{`  ${TAGLINE}  `}</text>
 					<text fg={colors.accent}>{`v${version}`}</text>
+					<text fg={result.executionSource === "project" ? colors.success : colors.fgDim}>{`  ·  ${result.executionSource}`}</text>
 				</box>
 			</box>
 

--- a/tests/local-resolution.test.ts
+++ b/tests/local-resolution.test.ts
@@ -1,0 +1,166 @@
+import {
+	mkdirSync,
+	mkdtempSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+	decideDelegation,
+	executionSource,
+	findRunningPackageRoot,
+	resolveLocalInstall,
+} from "../src/core/local-resolution.js";
+
+const GLOBAL_ROOT = "/usr/local/lib/node_modules/chowbea-axios";
+const LOCAL_ROOT = "/work/proj/node_modules/chowbea-axios";
+const LOCAL_BIN = "/work/proj/node_modules/chowbea-axios/bin/chowbea-axios.js";
+const localInstall = { root: LOCAL_ROOT, binPath: LOCAL_BIN };
+
+describe("decideDelegation", () => {
+	it("delegates to the local bin when a local install differs from the running one", () => {
+		expect(
+			decideDelegation({
+				runningRoot: GLOBAL_ROOT,
+				localInstall,
+				argv: ["node", "cli", "status"],
+				env: {},
+			}),
+		).toEqual({ action: "delegate", binPath: LOCAL_BIN });
+	});
+
+	it("runs as-is when there is no local install", () => {
+		expect(
+			decideDelegation({
+				runningRoot: GLOBAL_ROOT,
+				localInstall: null,
+				argv: ["node", "cli"],
+				env: {},
+			}),
+		).toEqual({ action: "run" });
+	});
+
+	it("runs as-is when the running install already IS the local one", () => {
+		expect(
+			decideDelegation({
+				runningRoot: LOCAL_ROOT,
+				localInstall,
+				argv: ["node", "cli"],
+				env: {},
+			}),
+		).toEqual({ action: "run" });
+	});
+
+	it("does not delegate when the loop-guard sentinel is set", () => {
+		expect(
+			decideDelegation({
+				runningRoot: GLOBAL_ROOT,
+				localInstall,
+				argv: ["node", "cli"],
+				env: { CHOWBEA_LOCAL_DELEGATED: "1" },
+			}),
+		).toEqual({ action: "run" });
+	});
+
+	it("does not delegate when CHOWBEA_NO_DELEGATE=1", () => {
+		expect(
+			decideDelegation({
+				runningRoot: GLOBAL_ROOT,
+				localInstall,
+				argv: ["node", "cli"],
+				env: { CHOWBEA_NO_DELEGATE: "1" },
+			}),
+		).toEqual({ action: "run" });
+	});
+
+	it("does not delegate when --global is passed", () => {
+		expect(
+			decideDelegation({
+				runningRoot: GLOBAL_ROOT,
+				localInstall,
+				argv: ["node", "cli", "--global", "status"],
+				env: {},
+			}),
+		).toEqual({ action: "run" });
+	});
+});
+
+describe("executionSource", () => {
+	it("is 'project' when the running root is the local install", () => {
+		expect(executionSource({ runningRoot: LOCAL_ROOT, localRoot: LOCAL_ROOT })).toBe(
+			"project",
+		);
+	});
+
+	it("is 'global' when a local exists but differs from the running root", () => {
+		expect(
+			executionSource({ runningRoot: GLOBAL_ROOT, localRoot: LOCAL_ROOT }),
+		).toBe("global");
+	});
+
+	it("is 'global' when there is no local install", () => {
+		expect(executionSource({ runningRoot: GLOBAL_ROOT, localRoot: null })).toBe(
+			"global",
+		);
+	});
+});
+
+describe("findRunningPackageRoot", () => {
+	it("walks up from a nested file to the nearest package.json", () => {
+		const root = mkdtempSync(join(tmpdir(), "chowbea-prr-"));
+		try {
+			writeFileSync(join(root, "package.json"), JSON.stringify({ name: "x" }));
+			const deep = join(root, "dist", "tui", "screens");
+			mkdirSync(deep, { recursive: true });
+			const file = join(deep, "home.js");
+			writeFileSync(file, "");
+			expect(findRunningPackageRoot(pathToFileURL(file).href)).toBe(
+				realpathSync(root),
+			);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("resolveLocalInstall", () => {
+	it("finds the project-local install and resolves its bin entry", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "chowbea-rli-"));
+		try {
+			const pkgRoot = join(cwd, "node_modules", "chowbea-axios");
+			mkdirSync(join(pkgRoot, "bin"), { recursive: true });
+			writeFileSync(
+				join(pkgRoot, "package.json"),
+				JSON.stringify({
+					name: "chowbea-axios",
+					version: "9.9.9",
+					bin: { "chowbea-axios": "bin/chowbea-axios.js" },
+				}),
+			);
+			writeFileSync(join(pkgRoot, "bin", "chowbea-axios.js"), "");
+
+			const result = resolveLocalInstall(cwd);
+			expect(result).not.toBeNull();
+			expect(result?.root).toBe(realpathSync(pkgRoot));
+			expect(result?.binPath).toBe(
+				join(realpathSync(pkgRoot), "bin", "chowbea-axios.js"),
+			);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("returns null when there is no project-local install", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "chowbea-rli-none-"));
+		try {
+			expect(resolveLocalInstall(cwd)).toBeNull();
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/local-resolution.test.ts
+++ b/tests/local-resolution.test.ts
@@ -163,4 +163,50 @@ describe("resolveLocalInstall", () => {
 			rmSync(cwd, { recursive: true, force: true });
 		}
 	});
+
+	it("walks up parent directories to find a hoisted install", () => {
+		const root = mkdtempSync(join(tmpdir(), "chowbea-rli-nested-"));
+		try {
+			const pkgRoot = join(root, "node_modules", "chowbea-axios");
+			mkdirSync(join(pkgRoot, "bin"), { recursive: true });
+			writeFileSync(
+				join(pkgRoot, "package.json"),
+				JSON.stringify({
+					name: "chowbea-axios",
+					version: "9.9.9",
+					bin: { "chowbea-axios": "bin/chowbea-axios.js" },
+				}),
+			);
+			writeFileSync(join(pkgRoot, "bin", "chowbea-axios.js"), "");
+			const nested = join(root, "packages", "app", "src");
+			mkdirSync(nested, { recursive: true });
+
+			expect(resolveLocalInstall(nested)?.root).toBe(realpathSync(pkgRoot));
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("resolves a string-form bin field", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "chowbea-rli-str-"));
+		try {
+			const pkgRoot = join(cwd, "node_modules", "chowbea-axios");
+			mkdirSync(join(pkgRoot, "bin"), { recursive: true });
+			writeFileSync(
+				join(pkgRoot, "package.json"),
+				JSON.stringify({
+					name: "chowbea-axios",
+					version: "9.9.9",
+					bin: "bin/chowbea-axios.js",
+				}),
+			);
+			writeFileSync(join(pkgRoot, "bin", "chowbea-axios.js"), "");
+
+			expect(resolveLocalInstall(cwd)?.binPath).toBe(
+				join(realpathSync(pkgRoot), "bin", "chowbea-axios.js"),
+			);
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
 });


### PR DESCRIPTION
## Why

The globally-installed `chowbea-axios` on `PATH` runs even when a project pins its own copy as a devDependency, so a developer can silently get a different version than the project expects. This makes the CLI prefer the **project-local** install — handing off to it so the pinned version actually runs — and surfaces which install is running.

## What changed

- `src/core/local-resolution.ts` (new) — pure helpers: resolve the project-local install (manual `node_modules` walk, to avoid `exports`/self-reference resolving the running package), decide whether to delegate, and report `project` vs `global`. Unit-tested.
- `src/router.ts` — at the top of `route()`, re-exec the project-local bin when the global is run inside a project that has its own copy (mirrors the existing Bun relaunch; loop-safe via a `CHOWBEA_LOCAL_DELEGATED` sentinel). `--global` and `CHOWBEA_NO_DELEGATE=1` opt out.
- `src/core/actions/status.ts` + `src/headless/formatters.ts` — the `status` action reports the execution source; `status` shows a `running   project/global install` line.
- `src/tui/screens/home.tsx` — Home shows `v… · project` / `· global` next to the version.
- `src/headless/runner.ts` — `--version` appends `(project)` / `(global)`; `--global` is stripped before per-command parsing.
- `tests/local-resolution.test.ts` (new) — 12 unit tests.

## Test plan

<!-- Verified: build + strict typecheck clean, 170 tests pass, and a real-binary e2e covering delegate / --global / CHOWBEA_NO_DELEGATE / no-local / run-local-directly. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CLI now automatically delegates execution to project-local installations when discovered
  * Status and version outputs display whether running from a project-local or global installation
  * TUI header indicates the execution source with visual highlighting for project installations

* **Tests**
  * Added comprehensive test coverage for local installation detection and delegation logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->